### PR TITLE
Varjo deferred fix

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.11.1"
+version = "0.11.2"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/lib/patchNotes.ts
+++ b/app/src/lib/patchNotes.ts
@@ -8,6 +8,16 @@ export interface PatchNoteEntry {
 
 export const patchNotes: PatchNoteEntry[] = [
   {
+    version: '0.11.2',
+    date: '2026-06-28',
+    title: 'Varjo Quadviews fix',
+    summary: 'Fixes a black-screen issue with Quadviews on Varjo headsets',
+    items: [
+      'Fixed a black screen on Varjo headsets when using VectorXR Quadviews; the focus and peripheral views are now composited correctly.',
+      'Each session log now records the VectorXR layer version to make troubleshooting easier.',
+    ],
+  },
+  {
     version: '0.11.1',
     date: '2026-06-27',
     title: 'Layer startup diagnostics',

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -84,12 +84,32 @@ if(WIN32 AND DEPTHXR_BUILD_LAYER)
         dxgi
         shlwapi
     )
+    # Derive the layer version from the single source of truth (tauri.conf.json) so
+    # the layer logs the same version the app reports. Set-Version.ps1 keeps that
+    # file current; CMake's project(VERSION) is a separate, unmanaged C++ version.
+    set(_vectorxr_version "unknown")
+    set(_vectorxr_tauri_conf "${CMAKE_SOURCE_DIR}/app/src-tauri/tauri.conf.json")
+    if(EXISTS "${_vectorxr_tauri_conf}")
+        file(READ "${_vectorxr_tauri_conf}" _vectorxr_tauri_contents)
+        string(JSON _vectorxr_version_parsed ERROR_VARIABLE _vectorxr_version_error
+               GET "${_vectorxr_tauri_contents}" version)
+        if(_vectorxr_version_error)
+            message(WARNING "Could not read version from ${_vectorxr_tauri_conf}: ${_vectorxr_version_error}")
+        else()
+            set(_vectorxr_version "${_vectorxr_version_parsed}")
+        endif()
+        # Re-run configure when the version bumps so the baked-in value never goes stale.
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_vectorxr_tauri_conf}")
+    endif()
+    message(STATUS "VectorXR layer version: ${_vectorxr_version}")
+
     target_compile_definitions(
         XR_APILAYER_DIENERTECH_VECTORXR
         PRIVATE
         WIN32_LEAN_AND_MEAN
         NOMINMAX
         XR_USE_GRAPHICS_API_D3D11
+        VECTORXR_VERSION="${_vectorxr_version}"
     )
 
     add_custom_command(

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -119,6 +119,7 @@ class OpenXrLayer {
         uint32_t last_acquired_image_index{0};
         bool images_enumerated{false};
         bool has_last_acquired_image_index{false};
+        bool release_deferred{false};
         bool quadviews_session{false};
         bool d3d11_shader_resources_attempted{false};
         bool d3d11_shader_resources_available{false};
@@ -185,6 +186,11 @@ class OpenXrLayer {
     bool IsQuadViewsActive() const;
     void ResetSwapchainState();
     void LogSwapchainSummary(XrSwapchain swapchain, const SwapchainInfo& info, std::string_view event_name);
+    bool ShouldDeferSwapchainRelease(const SwapchainInfo& info) const;
+    XrResult FlushDeferredSwapchainReleaseLocked(XrSwapchain swapchain,
+                                                 SwapchainInfo& info,
+                                                 std::string_view reason);
+    XrResult FlushDeferredSwapchainReleasesLocked(std::string_view reason);
     void ResetSessionState();
     void ResetInstanceState();
     void ResetD3D11QuadViewsCompositor();
@@ -263,6 +269,7 @@ class OpenXrLayer {
     XrSession resolved_settings_session_{XR_NULL_HANDLE};
     std::optional<std::chrono::steady_clock::time_point> last_config_check_time_;
     std::string last_failed_config_error_;
+    std::string runtime_name_;
     std::string current_exe_name_;
     ResolvedRuntimeConfig resolved_settings_;
     std::optional<ResolvedRuntimeConfig> last_logged_settings_;
@@ -291,6 +298,7 @@ class OpenXrLayer {
     bool quad_views_extension_requested_{false};
     bool varjo_foveated_rendering_extension_requested_{false};
     bool eye_gaze_extension_enabled_{false};
+    bool defer_quadviews_swapchain_releases_{false};
     XrSession active_session_{XR_NULL_HANDLE};
     XrSpace internal_local_space_{XR_NULL_HANDLE};
     XrSpace internal_view_space_{XR_NULL_HANDLE};

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -22,6 +22,13 @@
 #include "depthxr/seen_apps.h"
 #include "depthxr/sound_player.h"
 
+// Injected by layer/CMakeLists.txt from the canonical app version in
+// app/src-tauri/tauri.conf.json. Falls back when the layer is built without that
+// definition (e.g. the test target) so the symbol always resolves.
+#ifndef VECTORXR_VERSION
+#define VECTORXR_VERSION "unknown"
+#endif
+
 namespace depthxr {
 namespace {
 
@@ -892,6 +899,7 @@ XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
     logger_.Initialize(log_path_);
 
     current_exe_name_ = GetCurrentExecutableName();
+    logger_.Info(std::string("VectorXR layer version: ") + VECTORXR_VERSION);
     logger_.Info("VectorXR attached to process: " + current_exe_name_);
 
     if (create_info) {
@@ -4354,6 +4362,10 @@ void OpenXrLayer::ResetSwapchainState() {
 }
 
 bool OpenXrLayer::ShouldDeferSwapchainRelease(const SwapchainInfo& info) const {
+    // Deliberately scoped to every swapchain in the quadviews session, not just the
+    // four compositor inputs. The extra swapchains are still flushed before
+    // next_end_frame_, so submission ordering stays correct; keying off the session
+    // avoids tracking which handles are compositor inputs versus app-owned layers.
     return defer_quadviews_swapchain_releases_ && info.quadviews_session && info.session == active_session_ &&
            IsQuadViewsActive();
 }

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -947,10 +947,15 @@ XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
         XrInstanceProperties instance_properties{XR_TYPE_INSTANCE_PROPERTIES};
         const XrResult props_result = next_get_instance_properties_(instance_, &instance_properties);
         if (XR_SUCCEEDED(props_result)) {
+            runtime_name_ = instance_properties.runtimeName;
+            defer_quadviews_swapchain_releases_ = runtime_name_.find("Varjo") != std::string::npos;
             const XrVersion rt = instance_properties.runtimeVersion;
-            logger_.Info(std::string("OpenXR runtime: name=\"") + instance_properties.runtimeName +
+            logger_.Info(std::string("OpenXR runtime: name=\"") + runtime_name_ +
                          "\", version=" + std::to_string(XR_VERSION_MAJOR(rt)) + "." +
                          std::to_string(XR_VERSION_MINOR(rt)) + "." + std::to_string(XR_VERSION_PATCH(rt)));
+            if (defer_quadviews_swapchain_releases_) {
+                logger_.Info("Varjo runtime detected; deferring app quadviews swapchain releases until xrEndFrame.");
+            }
         } else {
             logger_.Info("OpenXR runtime identity unavailable: xrGetInstanceProperties returned " +
                          std::to_string(static_cast<int>(props_result)));
@@ -1091,6 +1096,7 @@ XrResult OpenXrLayer::DestroySession(XrSession session) {
         if (session == active_session_) {
             DestroyEyeGazeResources();
             DestroyInternalReferenceSpaces();
+            FlushDeferredSwapchainReleasesLocked("session teardown");
             ResetD3D11QuadViewsCompositor();
             ResetSwapchainState();
         }
@@ -1625,6 +1631,18 @@ XrResult OpenXrLayer::CreateSwapchain(XrSession session,
 }
 
 XrResult OpenXrLayer::DestroySwapchain(XrSwapchain swapchain) {
+    {
+        std::scoped_lock lock(mutex_);
+        auto it = tracked_swapchains_.find(swapchain);
+        if (it != tracked_swapchains_.end()) {
+            const XrResult flush_result =
+                FlushDeferredSwapchainReleaseLocked(swapchain, it->second, "swapchain destroy");
+            if (XR_FAILED(flush_result)) {
+                return flush_result;
+            }
+        }
+    }
+
     const XrResult result = next_destroy_swapchain_(swapchain);
     if (XR_FAILED(result)) {
         return result;
@@ -1691,6 +1709,18 @@ XrResult OpenXrLayer::EnumerateSwapchainImages(XrSwapchain swapchain,
 XrResult OpenXrLayer::AcquireSwapchainImage(XrSwapchain swapchain,
                                             const XrSwapchainImageAcquireInfo* acquire_info,
                                             uint32_t* index) {
+    {
+        std::scoped_lock lock(mutex_);
+        auto it = tracked_swapchains_.find(swapchain);
+        if (it != tracked_swapchains_.end()) {
+            const XrResult flush_result =
+                FlushDeferredSwapchainReleaseLocked(swapchain, it->second, "swapchain acquire");
+            if (XR_FAILED(flush_result)) {
+                return flush_result;
+            }
+        }
+    }
+
     const XrResult result = next_acquire_swapchain_image_(swapchain, acquire_info, index);
     if (XR_FAILED(result)) {
         return result;
@@ -1727,6 +1757,19 @@ XrResult OpenXrLayer::WaitSwapchainImage(XrSwapchain swapchain, const XrSwapchai
 
 XrResult OpenXrLayer::ReleaseSwapchainImage(XrSwapchain swapchain,
                                             const XrSwapchainImageReleaseInfo* release_info) {
+    {
+        std::scoped_lock lock(mutex_);
+        const auto it = tracked_swapchains_.find(swapchain);
+        if (it != tracked_swapchains_.end() && ShouldDeferSwapchainRelease(it->second)) {
+            it->second.release_deferred = true;
+            ++it->second.release_count;
+            if (it->second.quadviews_session && it->second.release_count <= 3) {
+                LogSwapchainSummary(swapchain, it->second, "releaseDeferred");
+            }
+            return XR_SUCCESS;
+        }
+    }
+
     const XrResult result = next_release_swapchain_image_(swapchain, release_info);
     if (XR_FAILED(result)) {
         return result;
@@ -2631,8 +2674,12 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         pivotxr_smoothed_extra_pitch_radians_ = 0.0;
         pivotxr_activation_gain_ = 0.0;
         pivotxr_last_smoothing_wall_time_.reset();
+        const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
         PrunePivotPoseDeltas(frame_end_info->displayTime);
         PruneQuadViewsFovs(frame_end_info->displayTime);
+        if (XR_FAILED(release_result)) {
+            return release_result;
+        }
         return next_end_frame_(session, frame_end_info);
     }
 
@@ -2707,8 +2754,12 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
             logger_.Debug(stream.str());
             --pending_end_frame_diagnostics_;
         }
+        const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
         PrunePivotPoseDeltas(frame_end_info->displayTime);
         PruneQuadViewsFovs(frame_end_info->displayTime);
+        if (XR_FAILED(release_result)) {
+            return release_result;
+        }
         return next_end_frame_(session, frame_end_info);
     }
 
@@ -2851,6 +2902,13 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                       ", unknownProjectionSwapchains=" + std::to_string(unknown_projection_swapchain_count) +
                       ", trackedSwapchains=" + std::to_string(tracked_swapchains_.size()));
     }
+    const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
+    if (XR_FAILED(release_result)) {
+        PrunePivotPoseDeltas(frame_end_info->displayTime);
+        PruneQuadViewsFovs(frame_end_info->displayTime);
+        return release_result;
+    }
+
     const XrResult result = next_end_frame_(session, &adjusted_frame_end_info);
     PrunePivotPoseDeltas(frame_end_info->displayTime);
     PruneQuadViewsFovs(frame_end_info->displayTime);
@@ -3494,6 +3552,8 @@ void OpenXrLayer::ResetInstanceState() {
     quad_views_extension_requested_ = false;
     varjo_foveated_rendering_extension_requested_ = false;
     eye_gaze_extension_enabled_ = false;
+    defer_quadviews_swapchain_releases_ = false;
+    runtime_name_.clear();
     cached_quadviews_stereo_recommended_width_ = 0;
     cached_quadviews_stereo_recommended_height_ = 0;
     has_logged_system_properties_ = false;
@@ -4293,6 +4353,50 @@ void OpenXrLayer::ResetSwapchainState() {
     tracked_swapchains_.clear();
 }
 
+bool OpenXrLayer::ShouldDeferSwapchainRelease(const SwapchainInfo& info) const {
+    return defer_quadviews_swapchain_releases_ && info.quadviews_session && info.session == active_session_ &&
+           IsQuadViewsActive();
+}
+
+XrResult OpenXrLayer::FlushDeferredSwapchainReleaseLocked(XrSwapchain swapchain,
+                                                          SwapchainInfo& info,
+                                                          std::string_view reason) {
+    if (!info.release_deferred) {
+        return XR_SUCCESS;
+    }
+    if (!next_release_swapchain_image_) {
+        logger_.Error("Deferred swapchain release failed: xrReleaseSwapchainImage is unavailable, reason=" +
+                      std::string(reason));
+        return XR_ERROR_RUNTIME_FAILURE;
+    }
+
+    XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    const XrResult result = next_release_swapchain_image_(swapchain, &release_info);
+    if (XR_FAILED(result)) {
+        logger_.Error("Deferred swapchain release failed: handle=" + FormatHandle(swapchain) +
+                      ", reason=" + std::string(reason) +
+                      ", result=" + FormatHex(static_cast<uint64_t>(result)));
+        return result;
+    }
+
+    info.release_deferred = false;
+    if (info.quadviews_session && info.release_count <= 3) {
+        LogSwapchainSummary(swapchain, info, "deferredReleaseFlushed");
+    }
+    return XR_SUCCESS;
+}
+
+XrResult OpenXrLayer::FlushDeferredSwapchainReleasesLocked(std::string_view reason) {
+    XrResult first_failure = XR_SUCCESS;
+    for (auto& [swapchain, info] : tracked_swapchains_) {
+        const XrResult result = FlushDeferredSwapchainReleaseLocked(swapchain, info, reason);
+        if (XR_FAILED(result) && XR_SUCCEEDED(first_failure)) {
+            first_failure = result;
+        }
+    }
+    return first_failure;
+}
+
 void OpenXrLayer::ResetD3D11QuadViewsCompositor() {
     for (QuadViewsCompositionTarget& target : d3d11_quadviews_compositor_.targets) {
         SafeReleaseVector(target.image_render_target_views);
@@ -4354,6 +4458,7 @@ void OpenXrLayer::LogSwapchainSummary(XrSwapchain swapchain,
            << ", acquires=" << info.acquire_count
            << ", waits=" << info.wait_count
            << ", releases=" << info.release_count
+           << ", releaseDeferred=" << info.release_deferred
            << ", trackedSwapchains=" << tracked_swapchains_.size();
     if (info.quadviews_session) {
         logger_.Info(stream.str());


### PR DESCRIPTION
- Fixed a black screen on Varjo headsets when using VectorXR Quadviews; the focus and peripheral views are now composited correctly
- Each session log now records the VectorXR layer version to make troubleshooting easier