### PR TITLE
Quadviews Focus & Sharpness Improvements

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.11.3",
+  "version": "0.11.4",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.11.3"
+version = "0.11.4"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -24,8 +24,10 @@ import { patchNotes } from './lib/patchNotes'
 import { applyThemePreference, loadThemePreference, observeSystemThemeChanges, type ThemePreference } from './lib/theme'
 import { validateConfig } from './lib/validation'
 import { useConfigStore } from './stores/configStore'
+import { useUpdateStore } from './stores/updateStore'
 
 const store = useConfigStore()
+const updateStore = useUpdateStore()
 const errors = computed(() => validateConfig(store.state.config))
 const dirty = computed(() => store.isDirty.value)
 const logViewerOpen = ref(false)
@@ -45,6 +47,13 @@ const openXrLayersLoading = ref(false)
 const openXrMachineWritesUnlocked = ref(false)
 
 const latestPatch = patchNotes[0]
+
+const updateAvailable = updateStore.updateAvailable
+const updateTooltip = computed(() =>
+  updateStore.state.latestRelease
+    ? `Version ${updateStore.state.latestRelease.version} is available. Click for details.`
+    : '',
+)
 const healthSummary = computed(() => buildHealthSummary({
   config: store.state.config,
   configPath: store.state.path,
@@ -136,6 +145,9 @@ onMounted(() => {
   void store.load()
   void refreshLogs()
   void refreshOpenXrLayers()
+  // Best-effort and fully non-blocking: detached from startup, failures are swallowed
+  // inside the store, so the indicator simply stays hidden and nothing else is affected.
+  void updateStore.check(latestPatch.version)
 })
 
 onUnmounted(() => {
@@ -149,6 +161,10 @@ async function saveConfig() {
   }
 
   await store.save()
+}
+
+function showUpdateDetails() {
+  store.setActiveTab('about')
 }
 
 async function refreshLogs() {
@@ -295,7 +311,15 @@ async function confirmResetConfig() {
 <template>
   <main class="app-shell-bg h-screen overflow-hidden">
     <section class="mx-auto flex h-full max-w-[1700px]">
-      <SidebarNav :active-tab="store.state.activeTab" :tabs="tabs" :version="latestPatch.version" @select="store.setActiveTab" />
+      <SidebarNav
+        :active-tab="store.state.activeTab"
+        :tabs="tabs"
+        :version="latestPatch.version"
+        :update-available="updateAvailable"
+        :update-tooltip="updateTooltip"
+        @select="store.setActiveTab"
+        @show-updates="showUpdateDetails"
+      />
 
       <div class="flex min-w-0 flex-1 flex-col px-4 py-3 md:px-6">
       <section class="min-h-0 flex-1 overflow-y-auto pb-1">

--- a/app/src/components/SidebarNav.vue
+++ b/app/src/components/SidebarNav.vue
@@ -7,6 +7,8 @@ import type { AppTab } from '../lib/model'
 const props = defineProps<{
   activeTab: AppTab
   version: string
+  updateAvailable?: boolean
+  updateTooltip?: string
   tabs: Array<{
     id: AppTab
     label: string
@@ -19,6 +21,7 @@ const props = defineProps<{
 
 defineEmits<{
   select: [tab: AppTab]
+  showUpdates: []
 }>()
 
 const primaryTabs = computed(() => props.tabs.filter((tab) => tab.id === 'home' || tab.id === 'core' || tab.id === 'registry' || tab.id === 'layers' || tab.id === 'about'))
@@ -79,7 +82,51 @@ function moduleDotClass(tab: { enhancementActive?: boolean }): string {
           <p class="text-sm font-semibold tracking-tight">VectorXR</p>
           <p class="text-[0.68rem] text-soft">v{{ version }}</p>
         </div>
+        <button
+          v-if="updateAvailable"
+          class="update-arrow ml-auto inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+          type="button"
+          :title="updateTooltip || 'A new version is available. Click for details.'"
+          aria-label="A new version is available"
+          @click="$emit('showUpdates')"
+        >
+          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+            <path fill-rule="evenodd" d="M10 3a1 1 0 0 1 .707.293l5 5a1 1 0 0 1-1.414 1.414L11 6.414V16a1 1 0 1 1-2 0V6.414L5.707 9.707a1 1 0 0 1-1.414-1.414l5-5A1 1 0 0 1 10 3Z" clip-rule="evenodd" />
+          </svg>
+        </button>
       </div>
     </div>
   </nav>
 </template>
+
+<style scoped>
+.update-arrow {
+  color: #22c55e;
+  border: 1px solid rgba(34, 197, 94, 0.45);
+  background: rgba(34, 197, 94, 0.12);
+  /* Slow, gentle blink a few times when it first appears, then settle fully visible. */
+  animation: update-arrow-blink 1s ease-in-out 3;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.update-arrow:hover {
+  transform: translateY(-1px);
+  background: rgba(34, 197, 94, 0.22);
+}
+
+@keyframes update-arrow-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .update-arrow {
+    animation: none;
+  }
+}
+</style>

--- a/app/src/components/tabs/AboutTab.vue
+++ b/app/src/components/tabs/AboutTab.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted } from 'vue'
 
 import { openExternalUrl } from '../../lib/commands'
 import type { PatchNoteEntry } from '../../lib/patchNotes'
-import { checkForUpdates, type GitHubReleaseInfo, type UpdateCheckStatus } from '../../lib/updates'
+import { useUpdateStore } from '../../stores/updateStore'
 
 const props = defineProps<{
   latestPatch: PatchNoteEntry
@@ -19,9 +19,11 @@ const koFiUrl = 'https://ko-fi.com/dienertech'
 const releasesUrl = 'https://github.com/DienerTech/vectorxr/releases/latest'
 const currentVersion = props.latestPatch.version
 
-const updateStatus = ref<UpdateCheckStatus>('idle')
-const updateError = ref('')
-const latestRelease = ref<GitHubReleaseInfo | null>(null)
+// Shared with the sidebar indicator so both reflect the same check result.
+const updateStore = useUpdateStore()
+const updateStatus = computed(() => updateStore.state.status)
+const updateError = computed(() => updateStore.state.error)
+const latestRelease = computed(() => updateStore.state.latestRelease)
 
 const releaseDate = computed(() => {
   if (!latestRelease.value?.publishedAt) {
@@ -97,29 +99,15 @@ async function openLink(url: string) {
   await openExternalUrl(url)
 }
 
-async function refreshUpdates() {
-  updateStatus.value = 'checking'
-  updateError.value = ''
-
-  try {
-    const result = await checkForUpdates(currentVersion)
-    latestRelease.value = result.latestRelease
-
-    if (!result.latestRelease) {
-      updateStatus.value = 'unavailable'
-    } else if (result.updateAvailable) {
-      updateStatus.value = 'available'
-    } else {
-      updateStatus.value = 'upToDate'
-    }
-  } catch (error) {
-    updateStatus.value = 'error'
-    updateError.value = error instanceof Error ? error.message : 'Unable to check for updates right now.'
-  }
+// Manual re-check from the "Check" button forces a fresh request.
+function refreshUpdates() {
+  void updateStore.check(currentVersion, true)
 }
 
 onMounted(() => {
-  void refreshUpdates()
+  // No-op if the startup check has already run; keeps the two entry points in sync
+  // without firing a duplicate request.
+  void updateStore.check(currentVersion)
 })
 </script>
 

--- a/app/src/components/tabs/PivotXrTab.vue
+++ b/app/src/components/tabs/PivotXrTab.vue
@@ -19,6 +19,7 @@ defineEmits<{
 }>()
 
 const compatibilityInfoOpen = ref(false)
+const centeringInfoOpen = ref(false)
 
 const profileWarnings = computed(() => {
   const warnings = new Map<number, string[]>()
@@ -65,16 +66,28 @@ const profileWarnings = computed(() => {
             Configure how Pivot activates and how much extra yaw or pitch it can add for each title. Use profiles to keep rotation behavior specific to the games and simulators that benefit from it.
           </p>
         </div>
-        <button
-          class="button-secondary inline-flex items-center gap-2 rounded-[0.75rem] px-4 py-2 text-sm font-medium"
-          type="button"
-          @click="compatibilityInfoOpen = true"
-        >
-          <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs" style="border-color: var(--app-border)">
-            i
-          </span>
-          Quadviews Compatibility
-        </button>
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            class="button-secondary inline-flex items-center gap-2 rounded-[0.75rem] px-4 py-2 text-sm font-medium"
+            type="button"
+            @click="compatibilityInfoOpen = true"
+          >
+            <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs" style="border-color: var(--app-border)">
+              i
+            </span>
+            Quadviews Compatibility
+          </button>
+          <button
+            class="button-secondary inline-flex items-center gap-2 rounded-[0.75rem] px-4 py-2 text-sm font-medium"
+            type="button"
+            @click="centeringInfoOpen = true"
+          >
+            <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs" style="border-color: var(--app-border)">
+              i
+            </span>
+            Centering &amp; Alignment
+          </button>
+        </div>
       </div>
 
       <details class="section-disclosure border-t pt-4" style="border-color: var(--app-border)" open>
@@ -178,6 +191,34 @@ const profileWarnings = computed(() => {
 
           <div class="rounded-[1rem] border px-4 py-4 surface-panel">
             You can inspect and change that order with the OpenXR Layer Manager tab in VectorXR.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="centeringInfoOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 py-6 backdrop-blur-sm">
+      <div class="w-full max-w-[720px] rounded-[1.25rem] border p-5 surface-panel-strong">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p class="eyebrow text-xs uppercase tracking-[0.24em]">Pivot Centering</p>
+            <h2 class="mt-2 text-xl font-semibold tracking-tight">Keeping Pivot Aligned</h2>
+          </div>
+          <button class="button-secondary rounded-[0.75rem] px-4 py-2 text-sm font-medium" type="button" @click="centeringInfoOpen = false">
+            Close
+          </button>
+        </div>
+
+        <div class="mt-5 space-y-4 text-sm leading-6">
+          <div class="rounded-[1rem] border px-4 py-4 surface-panel">
+            Pivot rotates around your headset's center point, not the game's. These are two separate concepts of "forward," and Pivot always uses the HMD one.
+          </div>
+
+          <div class="rounded-[1rem] border px-4 py-4 chip-warning" style="border-color: var(--app-border)">
+            If Pivot rotation feels off-center or skewed to one side, your HMD center and your in-game center have drifted apart.
+          </div>
+
+          <div class="rounded-[1rem] border px-4 py-4 surface-panel">
+            To fix it, recenter your HMD first, then recenter your view in the game. Doing both, in that order, re-aligns the two centers so Pivot rotates evenly around where you are actually looking.
           </div>
         </div>
       </div>

--- a/app/src/lib/model.ts
+++ b/app/src/lib/model.ts
@@ -286,11 +286,11 @@ export function defaultPivotXRSettings(): PivotXRSettings {
 export function defaultQuadViewsSettings(): QuadViewsSettings {
   return {
     trackingMode: 'eye',
-    focusHorizontalSizePercent: 32,
-    focusVerticalSizePercent: 32,
+    focusHorizontalSizePercent: 40,
+    focusVerticalSizePercent: 40,
     focusScale: 1.1,
-    peripheralScale: 0.45,
-    foveateSharpness: 0,
+    peripheralScale: 0.35,
+    foveateSharpness: 50,
     transitionThicknessPercent: 25,
     horizontalOffsetDegrees: 0,
     verticalOffsetDegrees: 0,

--- a/app/src/lib/patchNotes.ts
+++ b/app/src/lib/patchNotes.ts
@@ -8,6 +8,19 @@ export interface PatchNoteEntry {
 
 export const patchNotes: PatchNoteEntry[] = [
   {
+    version: '0.11.4',
+    date: '2026-07-01',
+    title: 'Quadviews Focus & Sharpness Improvements',
+    summary: 'Delivers the Quadviews focus region at full resolution end-to-end for a noticeably sharper image, turns on focus sharpening by default, retunes the default Quadviews profile, and adds deeper debug logging for focus resolution and eye tracking.',
+    items: [
+      'Fixed the Quadviews focus region being downscaled during compositing. The high-resolution focus view is now delivered at full 1:1 resolution, restoring sharpness that was previously lost and making the Focus Scale setting effective.',
+      'Dev Note: You may need to retune your Quadviews settings following this update. Previously, the Foveated Resolution setting was capped at 100%. Values above 100% will now apply correctly!',
+      'Focus sharpening now works correctly and is enabled by default, with edge clamping to avoid halos on high-contrast detail such as cockpit text and instruments. Further changes may be made here based on user feedback.',
+      'Retuned the default Quadviews profile with a larger focus region and lighter peripheral resolution for a sharper, more forgiving image out of the box at roughly a third of full-stereo pixel cost.',
+      'Added detailed Quadviews debug logging, including a focus sampling ratio and canvas density to confirm 1:1 focus rendering, plus eye-tracking interaction-profile diagnostics to help pinpoint why gaze-driven focus may be unavailable.',
+    ],
+  },
+  {
     version: '0.11.3',
     date: '2026-06-28',
     title: 'Varjo and Pivot diagnostics',

--- a/app/src/lib/patchNotes.ts
+++ b/app/src/lib/patchNotes.ts
@@ -18,6 +18,7 @@ export const patchNotes: PatchNoteEntry[] = [
       'Focus sharpening now works correctly and is enabled by default, with edge clamping to avoid halos on high-contrast detail such as cockpit text and instruments. Further changes may be made here based on user feedback.',
       'Retuned the default Quadviews profile with a larger focus region and lighter peripheral resolution for a sharper, more forgiving image out of the box at roughly a third of full-stereo pixel cost.',
       'Added detailed Quadviews debug logging, including a focus sampling ratio and canvas density to confirm 1:1 focus rendering, plus eye-tracking interaction-profile diagnostics to help pinpoint why gaze-driven focus may be unavailable.',
+      'Added a subtle update indicator next to the version number that appears when a newer release is available on GitHub, linking to the About page for details.',
     ],
   },
   {

--- a/app/src/lib/updates.ts
+++ b/app/src/lib/updates.ts
@@ -37,6 +37,9 @@ interface GitHubReleaseApiResponse {
 
 const latestReleaseUrl = 'https://api.github.com/repos/DienerTech/vectorxr/releases/latest'
 
+// Human-facing releases page, used as a fallback when we don't have a specific release object.
+export const releasesPageUrl = 'https://github.com/DienerTech/vectorxr/releases'
+
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/i, '')
 }

--- a/app/src/stores/updateStore.ts
+++ b/app/src/stores/updateStore.ts
@@ -1,0 +1,67 @@
+import { computed, reactive } from 'vue'
+
+import { checkForUpdates, type GitHubReleaseInfo, type UpdateCheckStatus } from '../lib/updates'
+
+interface UpdateState {
+  status: UpdateCheckStatus
+  error: string
+  latestRelease: GitHubReleaseInfo | null
+}
+
+// Single source of truth for the GitHub release check, shared between the sidebar
+// indicator and the About page so they can never disagree or show stale results.
+const state = reactive<UpdateState>({
+  status: 'idle',
+  error: '',
+  latestRelease: null,
+})
+
+let inFlight: Promise<void> | null = null
+
+const updateAvailable = computed(() => state.status === 'available' && state.latestRelease !== null)
+
+export function useUpdateStore() {
+  // Runs the release check and stores the result app-wide. Concurrent calls share the
+  // same in-flight request. `force` lets the About page's manual "Check" button re-run
+  // after a prior result; without it, a check is skipped once one has completed, so the
+  // startup auto-check and the About page's mount check never fire duplicate requests.
+  async function check(currentVersion: string, force = false): Promise<void> {
+    if (inFlight) {
+      return inFlight
+    }
+    if (!force && state.status !== 'idle') {
+      return
+    }
+
+    state.status = 'checking'
+    state.error = ''
+
+    inFlight = (async () => {
+      try {
+        const result = await checkForUpdates(currentVersion)
+        state.latestRelease = result.latestRelease
+
+        if (!result.latestRelease) {
+          state.status = 'unavailable'
+        } else if (result.updateAvailable) {
+          state.status = 'available'
+        } else {
+          state.status = 'upToDate'
+        }
+      } catch (error) {
+        state.status = 'error'
+        state.error = error instanceof Error ? error.message : 'Unable to check for updates right now.'
+      } finally {
+        inFlight = null
+      }
+    })()
+
+    return inFlight
+  }
+
+  return {
+    state,
+    updateAvailable,
+    check,
+  }
+}

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -372,6 +372,9 @@ class OpenXrLayer {
     XrPath eye_gaze_pose_path_{XR_NULL_PATH};
     bool eye_gaze_resources_ready_{false};
     bool eye_gaze_action_set_attached_{false};
+    bool has_logged_eye_gaze_focus_active_{false};
+    bool has_logged_eye_gaze_focus_unavailable_{false};
+    uint32_t eye_gaze_unavailable_streak_{0};
     double quadviews_smoothed_focus_yaw_radians_{0.0};
     double quadviews_smoothed_focus_pitch_radians_{0.0};
     std::optional<std::chrono::steady_clock::time_point> quadviews_last_focus_smoothing_wall_time_;

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -396,6 +396,8 @@ class OpenXrLayer {
     bool has_logged_system_properties_{false};
     uint32_t cached_quadviews_stereo_recommended_width_{0};
     uint32_t cached_quadviews_stereo_recommended_height_{0};
+    uint32_t cached_quadviews_stereo_max_width_{0};
+    uint32_t cached_quadviews_stereo_max_height_{0};
     std::unordered_set<XrSpace> tracked_view_spaces_;
     std::unordered_set<XrSpace> tracked_local_spaces_;
     std::unordered_set<XrSpace> tracked_stage_spaces_;
@@ -448,6 +450,8 @@ class OpenXrLayer {
     PFN_xrDestroyAction next_destroy_action_{nullptr};
     PFN_xrSuggestInteractionProfileBindings next_suggest_interaction_profile_bindings_{nullptr};
     PFN_xrGetActionStatePose next_get_action_state_pose_{nullptr};
+    PFN_xrGetCurrentInteractionProfile next_get_current_interaction_profile_{nullptr};
+    PFN_xrPathToString next_path_to_string_{nullptr};
     XrInstance instance_{XR_NULL_HANDLE};
 };
 

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -193,8 +193,11 @@ class OpenXrLayer {
         bool gpu_timing_available{false};
         bool has_logged_capabilities{false};
         bool has_logged_prewarm{false};
+        bool has_last_completed_gpu_timing{false};
         uint32_t failure_logs_remaining{8};
         uint32_t next_gpu_timing_query{0};
+        double last_completed_gpu_ms{0.0};
+        XrTime last_completed_gpu_frame_time{0};
         std::array<QuadViewsInputCopy, 4> input_copies;
         std::array<QuadViewsCompositionTarget, 2> targets;
         std::array<QuadViewsGpuTimingQuery, 4> gpu_timing_queries;
@@ -243,6 +246,8 @@ class OpenXrLayer {
                                                  SwapchainInfo& info,
                                                  std::string_view reason);
     XrResult FlushDeferredSwapchainReleasesLocked(std::string_view reason);
+    bool ShouldLogQuadViewsDebugHeartbeat(std::optional<std::chrono::steady_clock::time_point>& last_heartbeat);
+    void ResetQuadViewsDebugHeartbeatState();
     void ResetSessionState();
     void ResetInstanceState();
     void ResetD3D11QuadViewsCompositor();
@@ -341,6 +346,10 @@ class OpenXrLayer {
     uint32_t eye_gaze_diagnostic_stride_counter_{0};
     uint32_t pending_pivot_diagnostics_{0};
     uint64_t pivot_diagnostic_stride_counter_{0};
+    std::optional<std::chrono::steady_clock::time_point> last_quadviews_locate_debug_heartbeat_;
+    std::optional<std::chrono::steady_clock::time_point> last_quadviews_end_frame_debug_heartbeat_;
+    std::optional<std::chrono::steady_clock::time_point> last_quadviews_compositor_debug_heartbeat_;
+    std::optional<std::chrono::steady_clock::time_point> last_quadviews_eye_gaze_debug_heartbeat_;
     PivotDiagnosticState pivot_diagnostic_;
     double pivotxr_smoothed_extra_yaw_radians_{0.0};
     double pivotxr_smoothed_extra_pitch_radians_{0.0};

--- a/layer/include/depthxr/settings.h
+++ b/layer/include/depthxr/settings.h
@@ -157,11 +157,11 @@ struct PivotXrResolvedSettings {
 
 struct QuadViewsSettings {
     QuadViewsTrackingMode tracking_mode{QuadViewsTrackingMode::Eye};
-    double focus_horizontal_size_percent{32.0};
-    double focus_vertical_size_percent{32.0};
+    double focus_horizontal_size_percent{40.0};
+    double focus_vertical_size_percent{40.0};
     double focus_scale{1.1};
-    double peripheral_scale{0.45};
-    double foveate_sharpness{0.0};
+    double peripheral_scale{0.35};
+    double foveate_sharpness{50.0};
     double transition_thickness_percent{25.0};
     double horizontal_offset_degrees{0.0};
     double vertical_offset_degrees{0.0};

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -92,6 +92,17 @@ double QuadViewsFocusHeightScale(const QuadViewsResolvedSettings& settings) {
     return settings.focus_scale * Clamp(settings.focus_vertical_size_percent, 1.0, 100.0) / 100.0;
 }
 
+// Density multiplier for the full-FOV composite canvas relative to the runtime's
+// stereo-recommended resolution. The focus view is rendered at focus_scale x its
+// FOV fraction of stereo; for the focus texture to sample 1:1 into its sub-rectangle
+// of the canvas (rather than being downsampled back to stereo-native, which throws
+// away the whole point of a high-density inset), the canvas must span the full FOV
+// at focus_scale density. Never drop below 1.0 so the submitted layer keeps at least
+// stereo-native quality. This mirrors OpenXR-Quad-Views-Foveated's focus_multiplier.
+double QuadViewsCanvasDensity(const QuadViewsResolvedSettings& settings) {
+    return std::max(1.0, settings.focus_scale);
+}
+
 uint32_t EstimateFullResolutionDimension(uint32_t rendered_dimension, double render_scale) {
     const double scale = std::max(0.01, render_scale);
     return std::max<uint32_t>(1, static_cast<uint32_t>(std::round(static_cast<double>(rendered_dimension) / scale)));
@@ -1626,6 +1637,10 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
         std::max(stereo_views[0].recommendedImageRectWidth, stereo_views[1].recommendedImageRectWidth);
     cached_quadviews_stereo_recommended_height_ =
         std::max(stereo_views[0].recommendedImageRectHeight, stereo_views[1].recommendedImageRectHeight);
+    cached_quadviews_stereo_max_width_ =
+        std::max(stereo_views[0].maxImageRectWidth, stereo_views[1].maxImageRectWidth);
+    cached_quadviews_stereo_max_height_ =
+        std::max(stereo_views[0].maxImageRectHeight, stereo_views[1].maxImageRectHeight);
 
     for (uint32_t i = 0; i < 2; ++i) {
         void* app_next = views[i].next;
@@ -2356,22 +2371,35 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
     const double peripheral_scale = resolved_settings_.quadviews.peripheral_scale;
     const double focus_width_scale = QuadViewsFocusWidthScale(resolved_settings_.quadviews);
     const double focus_height_scale = QuadViewsFocusHeightScale(resolved_settings_.quadviews);
-    const uint32_t output_width = cached_quadviews_stereo_recommended_width_ > 0
-                                      ? cached_quadviews_stereo_recommended_width_
-                                      : std::max({
-                                            EstimateFullResolutionDimension(swapchains[0]->width, peripheral_scale),
-                                            EstimateFullResolutionDimension(swapchains[1]->width, peripheral_scale),
-                                            EstimateFullResolutionDimension(swapchains[2]->width, focus_width_scale),
-                                            EstimateFullResolutionDimension(swapchains[3]->width, focus_width_scale),
-                                        });
-    const uint32_t output_height = cached_quadviews_stereo_recommended_height_ > 0
-                                       ? cached_quadviews_stereo_recommended_height_
-                                       : std::max({
-                                             EstimateFullResolutionDimension(swapchains[0]->height, peripheral_scale),
-                                             EstimateFullResolutionDimension(swapchains[1]->height, peripheral_scale),
-                                             EstimateFullResolutionDimension(swapchains[2]->height, focus_height_scale),
-                                             EstimateFullResolutionDimension(swapchains[3]->height, focus_height_scale),
-                                         });
+    const double canvas_density = QuadViewsCanvasDensity(resolved_settings_.quadviews);
+
+    // Reconstruct the runtime's stereo-native full-FOV resolution (preferring the value
+    // cached during xrEnumerateViewConfigurationViews), then scale it by the focus density
+    // so the high-density focus view lands 1:1 in its sub-rectangle of the composite.
+    uint32_t stereo_full_width = cached_quadviews_stereo_recommended_width_;
+    uint32_t stereo_full_height = cached_quadviews_stereo_recommended_height_;
+    if (stereo_full_width == 0) {
+        stereo_full_width = std::max({
+            EstimateFullResolutionDimension(swapchains[0]->width, peripheral_scale),
+            EstimateFullResolutionDimension(swapchains[1]->width, peripheral_scale),
+            EstimateFullResolutionDimension(swapchains[2]->width, focus_width_scale),
+            EstimateFullResolutionDimension(swapchains[3]->width, focus_width_scale),
+        });
+    }
+    if (stereo_full_height == 0) {
+        stereo_full_height = std::max({
+            EstimateFullResolutionDimension(swapchains[0]->height, peripheral_scale),
+            EstimateFullResolutionDimension(swapchains[1]->height, peripheral_scale),
+            EstimateFullResolutionDimension(swapchains[2]->height, focus_height_scale),
+            EstimateFullResolutionDimension(swapchains[3]->height, focus_height_scale),
+        });
+    }
+    const uint32_t canvas_max_width =
+        cached_quadviews_stereo_max_width_ > 0 ? cached_quadviews_stereo_max_width_ : stereo_full_width * 4;
+    const uint32_t canvas_max_height =
+        cached_quadviews_stereo_max_height_ > 0 ? cached_quadviews_stereo_max_height_ : stereo_full_height * 4;
+    const uint32_t output_width = ScaleDimension(stereo_full_width, canvas_density, canvas_max_width);
+    const uint32_t output_height = ScaleDimension(stereo_full_height, canvas_density, canvas_max_height);
     const int64_t output_format = swapchains[2]->format;
     if (!EnsureD3D11QuadViewsCompositor(source_layer, output_width, output_height, output_format)) {
         return false;
@@ -2663,6 +2691,15 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                                                                resolved_settings_.quadviews.transition_thickness_percent,
                                                                resolved_settings_.quadviews.foveate_sharpness);
         if (should_log_compositor_diagnostic) {
+            // Effective focus sampling ratio: focus texture pixels vs. the output pixels its
+            // sub-rectangle occupies. ~1.0 = ideal 1:1; >1.0 = focus is being downsampled
+            // (blur, the pre-fix behaviour); <1.0 = focus canvas is larger than needed.
+            const double focus_rect_output_width =
+                std::max(1.0, static_cast<double>(constants.focus_rect[2] - constants.focus_rect[0]) * target.width);
+            const double focus_rect_output_height =
+                std::max(1.0, static_cast<double>(constants.focus_rect[3] - constants.focus_rect[1]) * target.height);
+            const double focus_sampling_ratio_x = focus_swapchain.width / focus_rect_output_width;
+            const double focus_sampling_ratio_y = focus_swapchain.height / focus_rect_output_height;
             std::ostringstream stream;
             stream << "D3D11 quadviews compositor focus rect: frameTime=" << display_time
                    << ", eye=" << eye
@@ -2673,6 +2710,11 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                    << FormatDiagnosticDouble(constants.focus_rect[1]) << ", "
                    << FormatDiagnosticDouble(constants.focus_rect[2]) << ", "
                    << FormatDiagnosticDouble(constants.focus_rect[3]) << ")"
+                   << ", focusTex=" << focus_swapchain.width << "x" << focus_swapchain.height
+                   << ", focusRectOutputPx=" << FormatDiagnosticDouble(focus_rect_output_width) << "x"
+                   << FormatDiagnosticDouble(focus_rect_output_height)
+                   << ", focusSamplingRatio=(" << FormatDiagnosticDouble(focus_sampling_ratio_x) << ", "
+                   << FormatDiagnosticDouble(focus_sampling_ratio_y) << ")"
                    << ", feather=(" << FormatDiagnosticDouble(constants.blend_params[0]) << ", "
                    << FormatDiagnosticDouble(constants.blend_params[1]) << ")"
                    << ", sharpness=" << FormatDiagnosticDouble(constants.blend_params[2])
@@ -2742,6 +2784,9 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                      std::to_string(output_width) + "x" + std::to_string(output_height) +
                      ", cachedStereoSize=" + std::to_string(cached_quadviews_stereo_recommended_width_) + "x" +
                      std::to_string(cached_quadviews_stereo_recommended_height_) +
+                     ", canvasDensity=" + FormatDiagnosticDouble(canvas_density) +
+                     ", focusTex=" + std::to_string(swapchains[2]->width) + "x" +
+                     std::to_string(swapchains[2]->height) +
                      ", directInputs=" + std::to_string(direct_input_count) + "/4" +
                      ", inputCopyFallbacks=" + std::to_string(input_copy_count) +
                      ", directOutputs=" + std::to_string(direct_output_count) + "/2" +
@@ -3957,6 +4002,16 @@ void OpenXrLayer::CaptureInstanceFunctions() {
     }
 
     function = nullptr;
+    if (XR_SUCCEEDED(next_get_instance_proc_addr_(instance_, "xrPathToString", &function))) {
+        next_path_to_string_ = reinterpret_cast<PFN_xrPathToString>(function);
+    }
+
+    function = nullptr;
+    if (XR_SUCCEEDED(next_get_instance_proc_addr_(instance_, "xrGetCurrentInteractionProfile", &function))) {
+        next_get_current_interaction_profile_ = reinterpret_cast<PFN_xrGetCurrentInteractionProfile>(function);
+    }
+
+    function = nullptr;
     if (XR_SUCCEEDED(next_get_instance_proc_addr_(instance_, "xrCreateActionSet", &function))) {
         next_create_action_set_ = reinterpret_cast<PFN_xrCreateActionSet>(function);
     }
@@ -4047,6 +4102,8 @@ void OpenXrLayer::ResetInstanceState() {
     runtime_name_.clear();
     cached_quadviews_stereo_recommended_width_ = 0;
     cached_quadviews_stereo_recommended_height_ = 0;
+    cached_quadviews_stereo_max_width_ = 0;
+    cached_quadviews_stereo_max_height_ = 0;
     has_logged_system_properties_ = false;
 }
 
@@ -4207,6 +4264,41 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
 
     *yaw_radians = 0.0;
     *pitch_radians = 0.0;
+
+    // Probe the runtime's current interaction profile for /user/eyes_ext. When our eye-gaze
+    // action reports isActive=0, this reveals *why*: "none" means the runtime never bound the
+    // eye-gaze profile (e.g. tracker not enabled/calibrated, or the extension isn't truly
+    // active downstream), whereas the eye-gaze profile string means the binding took and the
+    // problem is elsewhere. This is the single most useful signal for the Varjo blur report.
+    auto describe_eye_profile = [&]() -> std::string {
+        if (!next_get_current_interaction_profile_ || !next_string_to_path_ ||
+            active_session_ == XR_NULL_HANDLE) {
+            return "probe-unavailable";
+        }
+        XrPath user_path = XR_NULL_PATH;
+        if (XR_FAILED(next_string_to_path_(instance_, "/user/eyes_ext", &user_path))) {
+            return "no-user-path";
+        }
+        XrInteractionProfileState state{XR_TYPE_INTERACTION_PROFILE_STATE};
+        const XrResult probe_result =
+            next_get_current_interaction_profile_(active_session_, user_path, &state);
+        if (XR_FAILED(probe_result)) {
+            return "getCurrent-failed:" + FormatHex(static_cast<uint64_t>(probe_result));
+        }
+        if (state.interactionProfile == XR_NULL_PATH) {
+            return "none";
+        }
+        if (next_path_to_string_) {
+            char buffer[XR_MAX_PATH_LENGTH]{};
+            uint32_t length = 0;
+            if (XR_SUCCEEDED(next_path_to_string_(
+                    instance_, state.interactionProfile, sizeof(buffer), &length, buffer))) {
+                return std::string(buffer);
+            }
+        }
+        return "path#" + std::to_string(static_cast<uint64_t>(state.interactionProfile));
+    };
+
     auto log_eye_gaze_diagnostic = [&](const std::string& reason) {
         if (settings.tracking_mode == QuadViewsTrackingMode::Eye && !has_logged_eye_gaze_focus_unavailable_) {
             // Debounce: require the gaze to stay unavailable for several frames
@@ -4229,6 +4321,8 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
             logger_.Debug("Quadviews eye-gaze focus unavailable: " + reason +
                           ", resourcesReady=" + std::to_string(eye_gaze_resources_ready_) +
                           ", actionSetAttached=" + std::to_string(eye_gaze_action_set_attached_) +
+                          ", eyeInteractionProfile=" + describe_eye_profile() +
+                          ", eyeGazeExtEnabled=" + std::to_string(eye_gaze_extension_enabled_) +
                           ", unavailableStreak=" + std::to_string(eye_gaze_unavailable_streak_));
             if (pending_eye_gaze_diagnostics_ > 0) {
                 --pending_eye_gaze_diagnostics_;

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -375,6 +375,12 @@ FocusRectConstants BuildFocusRectConstants(const XrFovf& full_fov,
     constants.blend_params[3] = 0.0f;
     constants.focus_texel[0] = 1.0f / static_cast<float>(std::max<uint32_t>(1, focus_width));
     constants.focus_texel[1] = 1.0f / static_cast<float>(std::max<uint32_t>(1, focus_height));
+    // One output pixel expressed in focus-UV, so inline sharpening samples at output-pixel
+    // spacing (frequencies that survive the focus->output resample) instead of focus-texel scale.
+    constants.focus_texel[2] =
+        static_cast<float>((1.0 / std::max<uint32_t>(1, width)) / focus_rect_width);
+    constants.focus_texel[3] =
+        static_cast<float>((1.0 / std::max<uint32_t>(1, height)) / focus_rect_height);
     return constants;
 }
 
@@ -425,16 +431,24 @@ float4 PSMain(VSOut input) : SV_Target {
 
     float2 focusUv = saturate((uv - focusRect.xy) / max(focusRect.zw - focusRect.xy, float2(0.0001, 0.0001)));
     float4 focus = focusTexture.Sample(linearSampler, focusUv);
-    float sharpenAmount = saturate(blendParams.z) * 0.35;
+    float sharpenAmount = saturate(blendParams.z);
     if (sharpenAmount > 0.001) {
-        float2 texel = focusTexel.xy;
-        float4 blur =
-            focusTexture.Sample(linearSampler, saturate(focusUv + float2(texel.x, 0.0))) +
-            focusTexture.Sample(linearSampler, saturate(focusUv - float2(texel.x, 0.0))) +
-            focusTexture.Sample(linearSampler, saturate(focusUv + float2(0.0, texel.y))) +
-            focusTexture.Sample(linearSampler, saturate(focusUv - float2(0.0, texel.y)));
-        blur *= 0.25;
-        focus.rgb = saturate(focus.rgb + (focus.rgb - blur.rgb) * sharpenAmount);
+        // Sample neighbors at output-pixel spacing (focusTexel.zw is one output pixel expressed
+        // in focus-UV), not focus-texel spacing. The focus texture is minified into the focus
+        // rect, so a focus-texel-scale unsharp mask synthesizes detail that the resample averages
+        // away; output-space offsets target the frequencies the user actually sees.
+        float2 off = focusTexel.zw;
+        float3 n = focusTexture.Sample(linearSampler, saturate(focusUv + float2(0.0, -off.y))).rgb;
+        float3 s = focusTexture.Sample(linearSampler, saturate(focusUv + float2(0.0,  off.y))).rgb;
+        float3 e = focusTexture.Sample(linearSampler, saturate(focusUv + float2( off.x, 0.0))).rgb;
+        float3 w = focusTexture.Sample(linearSampler, saturate(focusUv + float2(-off.x, 0.0))).rgb;
+        float3 avg = (n + s + e + w) * 0.25;
+        float3 sharpened = focus.rgb + (focus.rgb - avg) * sharpenAmount;
+        // CAS-style clamp: keep the result inside the local neighborhood range so strong
+        // sharpening cannot ring into bright halos on high-contrast edges (cockpit text/MFDs).
+        float3 lo = min(focus.rgb, min(min(n, s), min(e, w)));
+        float3 hi = max(focus.rgb, max(max(n, s), max(e, w)));
+        focus.rgb = clamp(sharpened, lo, hi);
     }
 
     float2 distToEdge = min(uv - focusRect.xy, focusRect.zw - uv);
@@ -2662,6 +2676,11 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                    << ", feather=(" << FormatDiagnosticDouble(constants.blend_params[0]) << ", "
                    << FormatDiagnosticDouble(constants.blend_params[1]) << ")"
                    << ", sharpness=" << FormatDiagnosticDouble(constants.blend_params[2])
+                   << ", sharpenBackend=inlineAdaptive"
+                   << ", outputTexel=(" << FormatDiagnosticDouble(constants.focus_texel[2]) << ", "
+                   << FormatDiagnosticDouble(constants.focus_texel[3]) << ")"
+                   << ", focusTexel=(" << FormatDiagnosticDouble(constants.focus_texel[0]) << ", "
+                   << FormatDiagnosticDouble(constants.focus_texel[1]) << ")"
                    << ", fullFov=" << FormatFov(full_fov)
                    << ", focusFov=" << FormatFov(focus_fov)
                    << ", sourceFullFov=" << FormatFov(source_layer->views[eye].fov)

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -815,6 +815,7 @@ constexpr uint64_t kPivotDiagnosticStride = 120;
 // Debounces sub-second dropouts (e.g. blinks, which invalidate the gaze pose for
 // ~100-400ms) so transient gaze loss does not churn the log. ~1/3s at 90Hz.
 constexpr uint32_t kEyeGazeUnavailableLogThreshold = 30;
+constexpr std::chrono::seconds kQuadViewsDebugHeartbeatInterval{2};
 // Hot-path throttles. xrLocateSpace/xrLocateViews/xrEndFrame run multiple
 // times per frame; filesystem stats, input-device polls, and downstream
 // helper calls must not.
@@ -2450,6 +2451,9 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                         static_cast<double>(end_timestamp - start_timestamp) /
                         static_cast<double>(disjoint.Frequency) * 1000.0;
                     completed_gpu_frame_time = query.frame_time;
+                    d3d11_quadviews_compositor_.has_last_completed_gpu_timing = true;
+                    d3d11_quadviews_compositor_.last_completed_gpu_ms = completed_gpu_ms;
+                    d3d11_quadviews_compositor_.last_completed_gpu_frame_time = completed_gpu_frame_time;
                 }
                 query.issued = false;
                 break;
@@ -2457,8 +2461,11 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         }
     }
 
+    const bool should_log_compositor_diagnostic =
+        pending_quadviews_compositor_diagnostics_ > 0 ||
+        ShouldLogQuadViewsDebugHeartbeat(last_quadviews_compositor_debug_heartbeat_);
     QuadViewsGpuTimingQuery* active_gpu_query = nullptr;
-    if (pending_quadviews_compositor_diagnostics_ > 0 && d3d11_quadviews_compositor_.gpu_timing_available) {
+    if (should_log_compositor_diagnostic && d3d11_quadviews_compositor_.gpu_timing_available) {
         QuadViewsGpuTimingQuery& query =
             d3d11_quadviews_compositor_.gpu_timing_queries[d3d11_quadviews_compositor_.next_gpu_timing_query %
                                                            d3d11_quadviews_compositor_.gpu_timing_queries.size()];
@@ -2641,7 +2648,7 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                                                                focus_swapchain.height,
                                                                resolved_settings_.quadviews.transition_thickness_percent,
                                                                resolved_settings_.quadviews.foveate_sharpness);
-        if (pending_quadviews_compositor_diagnostics_ > 0) {
+        if (should_log_compositor_diagnostic) {
             std::ostringstream stream;
             stream << "D3D11 quadviews compositor focus rect: frameTime=" << display_time
                    << ", eye=" << eye
@@ -2728,9 +2735,15 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                      "%");
         d3d11_quadviews_compositor_.has_logged_capabilities = true;
     }
-    if (pending_quadviews_compositor_diagnostics_ > 0) {
+    if (should_log_compositor_diagnostic) {
         const auto compose_end = std::chrono::steady_clock::now();
         const double cpu_ms = std::chrono::duration<double, std::milli>(compose_end - compose_start).count();
+        const bool has_completed_gpu_ms =
+            completed_gpu_ms >= 0.0 || d3d11_quadviews_compositor_.has_last_completed_gpu_timing;
+        const double logged_gpu_ms = completed_gpu_ms >= 0.0 ? completed_gpu_ms :
+            d3d11_quadviews_compositor_.last_completed_gpu_ms;
+        const XrTime logged_gpu_frame_time = completed_gpu_ms >= 0.0 ? completed_gpu_frame_time :
+            d3d11_quadviews_compositor_.last_completed_gpu_frame_time;
         std::ostringstream stream;
         stream << "D3D11 quadviews compositor frame: frameTime=" << display_time
                << ", cpuMs=" << FormatDiagnosticDouble(cpu_ms)
@@ -2741,16 +2754,18 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                << ", inputCopies=" << input_copy_count
                << ", directOutputs=" << direct_output_count
                << ", outputCopies=" << output_copy_count
-               << ", completedGpuFrameTime=" << completed_gpu_frame_time
+               << ", completedGpuFrameTime=" << logged_gpu_frame_time
                << ", completedGpuMs="
-               << (completed_gpu_ms >= 0.0 ? FormatDiagnosticDouble(completed_gpu_ms) : "pending")
+               << (has_completed_gpu_ms ? FormatDiagnosticDouble(logged_gpu_ms) : "pending")
                << ", appPixelBudget=" << FormatDiagnosticDouble(
                       (static_cast<double>(swapchains[0]->width) * swapchains[0]->height +
                        static_cast<double>(swapchains[2]->width) * swapchains[2]->height) /
                       std::max(1.0, static_cast<double>(output_width) * output_height) * 100.0)
                << "%";
         logger_.Debug(stream.str());
-        --pending_quadviews_compositor_diagnostics_;
+        if (pending_quadviews_compositor_diagnostics_ > 0) {
+            --pending_quadviews_compositor_diagnostics_;
+        }
     }
 
     composed_views->assign(source_layer->views, source_layer->views + 2);
@@ -2808,6 +2823,10 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         IsQuadViewsActive() && has_active_primary_view_configuration_ &&
         IsQuadViewConfiguration(active_primary_view_configuration_type_) &&
         active_runtime_view_configuration_type_ == XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    const bool should_log_end_frame_diagnostic =
+        pending_end_frame_diagnostics_ > 0 ||
+        (quadviews_projection_split_active &&
+         ShouldLogQuadViewsDebugHeartbeat(last_quadviews_end_frame_debug_heartbeat_));
 
     if (!resolved_settings_.pivotxr.enabled) {
         cached_pivot_pose_deltas_.clear();
@@ -2832,7 +2851,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     // pose/FOV survives into the composition layer the runtime presents, or
     // whether the app re-derives its own. Does not consume the counter; the
     // branch diagnostics below own the decrement.
-    if (pending_end_frame_diagnostics_ > 0) {
+    if (should_log_end_frame_diagnostic) {
         for (uint32_t i = 0; i < frame_end_info->layerCount; ++i) {
             const XrCompositionLayerBaseHeader* base_header = frame_end_info->layers[i];
             if (!base_header || base_header->type != XR_TYPE_COMPOSITION_LAYER_PROJECTION) {
@@ -2866,7 +2885,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     }
 
     if (!has_non_identity_delta && !quadviews_projection_split_active) {
-        if (pending_end_frame_diagnostics_ > 0) {
+        if (should_log_end_frame_diagnostic) {
             std::ostringstream stream;
             stream << "EndFrame pivot correction skipped: cacheHit=" << has_pose_delta
                    << ", frameTime=" << frame_end_info->displayTime;
@@ -2876,7 +2895,9 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
             }
             stream << ", cachedPivotDeltas=" << cached_pivot_pose_deltas_.size();
             logger_.Debug(stream.str());
-            --pending_end_frame_diagnostics_;
+            if (pending_end_frame_diagnostics_ > 0) {
+                --pending_end_frame_diagnostics_;
+            }
         }
         const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
         PrunePivotPoseDeltas(frame_end_info->displayTime);
@@ -2992,7 +3013,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     XrFrameEndInfo adjusted_frame_end_info = *frame_end_info;
     adjusted_frame_end_info.layerCount = static_cast<uint32_t>(adjusted_layers.size());
     adjusted_frame_end_info.layers = adjusted_layers.data();
-    if (pending_end_frame_diagnostics_ > 0) {
+    if (should_log_end_frame_diagnostic) {
         const ViewOrientation delta_orientation{
             pose_delta.orientation.x,
             pose_delta.orientation.y,
@@ -3014,17 +3035,9 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                << ", trackedSwapchains=" << tracked_swapchains_.size()
                << ", cachedPivotDeltas=" << cached_pivot_pose_deltas_.size();
         logger_.Debug(stream.str());
-        --pending_end_frame_diagnostics_;
-    } else if (quadviews_projection_split_active && split_quad_projection_layer_count > 0 &&
-               logger_.IsDebugEnabled()) {
-        logger_.Debug("EndFrame quadviews projection split applied: splitLayers=" +
-                      std::to_string(split_quad_projection_layer_count) +
-                      ", d3d11QuadCompositions=" + std::to_string(d3d11_quad_composition_count) +
-                      ", submittedLayers=" + std::to_string(frame_end_info->layerCount) +
-                      ", runtimeLayers=" + std::to_string(adjusted_layers.size()) +
-                      ", projectionSwapchainRefs=" + std::to_string(projection_swapchain_reference_count) +
-                      ", unknownProjectionSwapchains=" + std::to_string(unknown_projection_swapchain_count) +
-                      ", trackedSwapchains=" + std::to_string(tracked_swapchains_.size()));
+        if (pending_end_frame_diagnostics_ > 0) {
+            --pending_end_frame_diagnostics_;
+        }
     }
     const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
     if (XR_FAILED(release_result)) {
@@ -3409,7 +3422,11 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
         }
     }
 
-    if (pending_locate_views_diagnostics_ > 0 || should_log_pivot_diagnostic) {
+    const bool should_log_quadviews_locate_heartbeat =
+        (IsQuadViewConfiguration(view_configuration_type) || synthesized_quad_views) &&
+        ShouldLogQuadViewsDebugHeartbeat(last_quadviews_locate_debug_heartbeat_);
+    if (pending_locate_views_diagnostics_ > 0 || should_log_pivot_diagnostic ||
+        should_log_quadviews_locate_heartbeat) {
         const double left_position_delta =
             adjusted_views[0].position.x - original_views[0].position.x;
         const double right_position_delta =
@@ -3441,10 +3458,18 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                             ExtractPitchRadians(original_views[1].orientation)
                       : 0.0;
 
-        if (pending_locate_views_diagnostics_ > 0) {
+        if (pending_locate_views_diagnostics_ > 0 || should_log_quadviews_locate_heartbeat) {
             std::ostringstream stream;
-            stream << "LocateViews call " << locate_views_call_count_ << ": count=" << count
+            stream << "LocateViews "
+                   << (should_log_quadviews_locate_heartbeat && pending_locate_views_diagnostics_ == 0 ?
+                           "quadviews heartbeat " : "call ")
+                   << locate_views_call_count_ << ": count=" << count
                    << ", viewConfig=" << ToString(view_configuration_type)
+                   << ", synthesizedQuadViews=" << synthesized_quad_views
+                   << ", quadviewsTrackingMode=" << ToString(resolved_settings_.quadviews.tracking_mode)
+                   << ", quadviewsFocusScale=" << FormatDiagnosticDouble(resolved_settings_.quadviews.focus_scale)
+                   << ", quadviewsPeripheralScale="
+                   << FormatDiagnosticDouble(resolved_settings_.quadviews.peripheral_scale)
                    << ", pivotExtraYawRadians=" << FormatDiagnosticDouble(pivotxr_smoothed_extra_yaw_radians_)
                    << ", pivotExtraPitchRadians=" << FormatDiagnosticDouble(pivotxr_smoothed_extra_pitch_radians_)
                    << ", pivotActivationGain=" << FormatDiagnosticDouble(pivotxr_activation_gain_)
@@ -3466,7 +3491,9 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
             stream << " after:";
             AppendViewSummary(stream, adjusted_views);
             logger_.Debug(stream.str());
-            --pending_locate_views_diagnostics_;
+            if (pending_locate_views_diagnostics_ > 0) {
+                --pending_locate_views_diagnostics_;
+            }
         }
 
         if (should_log_pivot_diagnostic) {
@@ -3746,6 +3773,7 @@ void OpenXrLayer::RefreshResolvedSettings() {
         pending_pivot_diagnostics_ = kPivotDiagnosticBurstCount;
         pending_eye_gaze_diagnostics_ = 10;
         pending_eye_gaze_sync_diagnostics_ = 10;
+        ResetQuadViewsDebugHeartbeatState();
     }
 
     if (IsQuadViewsActive() && resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye &&
@@ -3951,6 +3979,7 @@ void OpenXrLayer::ResetSessionState() {
     eye_gaze_diagnostic_stride_counter_ = 0;
     pending_pivot_diagnostics_ = 0;
     pivot_diagnostic_stride_counter_ = 0;
+    ResetQuadViewsDebugHeartbeatState();
     pivot_diagnostic_ = PivotDiagnosticState{};
     pivotxr_smoothed_extra_yaw_radians_ = 0.0;
     pivotxr_smoothed_extra_pitch_radians_ = 0.0;
@@ -4004,6 +4033,28 @@ void OpenXrLayer::ResetInstanceState() {
 
 bool OpenXrLayer::IsQuadViewsActive() const {
     return resolved_settings_.core.enabled && resolved_settings_.quadviews.enabled;
+}
+
+bool OpenXrLayer::ShouldLogQuadViewsDebugHeartbeat(
+    std::optional<std::chrono::steady_clock::time_point>& last_heartbeat) {
+    if (!logger_.IsDebugEnabled() || !IsQuadViewsActive()) {
+        last_heartbeat.reset();
+        return false;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (last_heartbeat.has_value() && now - *last_heartbeat < kQuadViewsDebugHeartbeatInterval) {
+        return false;
+    }
+    last_heartbeat = now;
+    return true;
+}
+
+void OpenXrLayer::ResetQuadViewsDebugHeartbeatState() {
+    last_quadviews_locate_debug_heartbeat_.reset();
+    last_quadviews_end_frame_debug_heartbeat_.reset();
+    last_quadviews_compositor_debug_heartbeat_.reset();
+    last_quadviews_eye_gaze_debug_heartbeat_.reset();
 }
 
 XrResult OpenXrLayer::CreateEyeGazeResources(XrSession session) {
@@ -4151,11 +4202,18 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
                 has_logged_eye_gaze_focus_active_ = false;
             }
         }
-        if (settings.tracking_mode == QuadViewsTrackingMode::Eye && pending_eye_gaze_diagnostics_ > 0) {
+        const bool should_log_unavailable_debug =
+            settings.tracking_mode == QuadViewsTrackingMode::Eye &&
+            (pending_eye_gaze_diagnostics_ > 0 ||
+             ShouldLogQuadViewsDebugHeartbeat(last_quadviews_eye_gaze_debug_heartbeat_));
+        if (should_log_unavailable_debug) {
             logger_.Debug("Quadviews eye-gaze focus unavailable: " + reason +
                           ", resourcesReady=" + std::to_string(eye_gaze_resources_ready_) +
-                          ", actionSetAttached=" + std::to_string(eye_gaze_action_set_attached_));
-            --pending_eye_gaze_diagnostics_;
+                          ", actionSetAttached=" + std::to_string(eye_gaze_action_set_attached_) +
+                          ", unavailableStreak=" + std::to_string(eye_gaze_unavailable_streak_));
+            if (pending_eye_gaze_diagnostics_ > 0) {
+                --pending_eye_gaze_diagnostics_;
+            }
         }
     };
 
@@ -4258,11 +4316,14 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
 
     *yaw_radians = quadviews_smoothed_focus_yaw_radians_;
     *pitch_radians = quadviews_smoothed_focus_pitch_radians_;
-    const bool should_log_eye_gaze =
+    const bool should_log_eye_gaze_burst =
         pending_eye_gaze_diagnostics_ > 0 &&
         (eye_gaze_diagnostic_stride_counter_ < 20 || eye_gaze_diagnostic_stride_counter_ % 45 == 0);
+    const bool should_log_eye_gaze_heartbeat =
+        !should_log_eye_gaze_burst &&
+        ShouldLogQuadViewsDebugHeartbeat(last_quadviews_eye_gaze_debug_heartbeat_);
     ++eye_gaze_diagnostic_stride_counter_;
-    if (should_log_eye_gaze) {
+    if (should_log_eye_gaze_burst || should_log_eye_gaze_heartbeat) {
         logger_.Debug("Quadviews eye-gaze focus active: rawYaw=" + FormatDiagnosticDouble(target_yaw) +
                       ", rawPitch=" + FormatDiagnosticDouble(target_pitch) +
                       ", eulerYaw=" + FormatDiagnosticDouble(euler_yaw) +
@@ -4272,8 +4333,13 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
                       ", forward=(" + FormatDiagnosticDouble(gaze_ray_angles.forward.x) + ", " +
                       FormatDiagnosticDouble(gaze_ray_angles.forward.y) + ", " +
                       FormatDiagnosticDouble(gaze_ray_angles.forward.z) + ")" +
-                      ", baseSpace=" + std::string(gaze_base_space == internal_view_space_ ? "view" : "app"));
-        --pending_eye_gaze_diagnostics_;
+                      ", baseSpace=" + std::string(gaze_base_space == internal_view_space_ ? "view" : "app") +
+                      ", locationFlags=" + FormatHex(static_cast<uint64_t>(gaze_location.locationFlags)) +
+                      ", appSyncFresh=" + std::to_string(app_sync_fresh) +
+                      ", heartbeat=" + std::to_string(should_log_eye_gaze_heartbeat));
+        if (should_log_eye_gaze_burst && pending_eye_gaze_diagnostics_ > 0) {
+            --pending_eye_gaze_diagnostics_;
+        }
     }
     // Gaze recovered this frame; clear the unavailable streak so a future
     // dropout must persist past the debounce threshold again before it logs.
@@ -4973,8 +5039,11 @@ void OpenXrLayer::ResetD3D11QuadViewsCompositor() {
     d3d11_quadviews_compositor_.gpu_timing_available = false;
     d3d11_quadviews_compositor_.has_logged_capabilities = false;
     d3d11_quadviews_compositor_.has_logged_prewarm = false;
+    d3d11_quadviews_compositor_.has_last_completed_gpu_timing = false;
     d3d11_quadviews_compositor_.failure_logs_remaining = 8;
     d3d11_quadviews_compositor_.next_gpu_timing_query = 0;
+    d3d11_quadviews_compositor_.last_completed_gpu_ms = 0.0;
+    d3d11_quadviews_compositor_.last_completed_gpu_frame_time = 0;
 }
 
 void OpenXrLayer::LogSwapchainSummary(XrSwapchain swapchain,

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -340,6 +340,8 @@ FocusRectConstants BuildFocusRectConstants(const XrFovf& full_fov,
                                            const XrFovf& focus_fov,
                                            uint32_t width,
                                            uint32_t height,
+                                           uint32_t focus_width,
+                                           uint32_t focus_height,
                                            double transition_thickness_percent,
                                            double foveate_sharpness) {
     const double full_left = std::tan(full_fov.angleLeft);
@@ -364,14 +366,15 @@ FocusRectConstants BuildFocusRectConstants(const XrFovf& full_fov,
     const double focus_rect_height =
         std::max(0.0001, static_cast<double>(constants.focus_rect[3]) - constants.focus_rect[1]);
     const double transition_fraction = Clamp(transition_thickness_percent, 0.0, 100.0) / 100.0;
+    // Feathering is measured in output pixels, while sharpening samples the focus texture.
     constants.blend_params[0] = static_cast<float>(std::max(1.0 / std::max<uint32_t>(1, width),
                                                            focus_rect_width * transition_fraction));
     constants.blend_params[1] = static_cast<float>(std::max(1.0 / std::max<uint32_t>(1, height),
                                                            focus_rect_height * transition_fraction));
     constants.blend_params[2] = static_cast<float>(Clamp(foveate_sharpness, 0.0, 100.0) / 100.0);
     constants.blend_params[3] = 0.0f;
-    constants.focus_texel[0] = 1.0f / static_cast<float>(std::max<uint32_t>(1, width));
-    constants.focus_texel[1] = 1.0f / static_cast<float>(std::max<uint32_t>(1, height));
+    constants.focus_texel[0] = 1.0f / static_cast<float>(std::max<uint32_t>(1, focus_width));
+    constants.focus_texel[1] = 1.0f / static_cast<float>(std::max<uint32_t>(1, focus_height));
     return constants;
 }
 
@@ -808,6 +811,10 @@ constexpr XrTime kMaxQuadViewsFovMatchWindow = 5'000'000;
 constexpr size_t kMaxCachedQuadViewsFovFrames = 180;
 constexpr uint32_t kPivotDiagnosticBurstCount = 8;
 constexpr uint64_t kPivotDiagnosticStride = 120;
+// Consecutive unavailable frames before the eye-gaze focus is logged as lost.
+// Debounces sub-second dropouts (e.g. blinks, which invalidate the gaze pose for
+// ~100-400ms) so transient gaze loss does not churn the log. ~1/3s at 90Hz.
+constexpr uint32_t kEyeGazeUnavailableLogThreshold = 30;
 // Hot-path throttles. xrLocateSpace/xrLocateViews/xrEndFrame run multiple
 // times per frame; filesystem stats, input-device polls, and downstream
 // helper calls must not.
@@ -2630,6 +2637,8 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                                                                focus_fov,
                                                                target.width,
                                                                target.height,
+                                                               focus_swapchain.width,
+                                                               focus_swapchain.height,
                                                                resolved_settings_.quadviews.transition_thickness_percent,
                                                                resolved_settings_.quadviews.foveate_sharpness);
         if (pending_quadviews_compositor_diagnostics_ > 0) {
@@ -3959,6 +3968,9 @@ void OpenXrLayer::ResetSessionState() {
     eye_gaze_pose_path_ = XR_NULL_PATH;
     eye_gaze_resources_ready_ = false;
     eye_gaze_action_set_attached_ = false;
+    has_logged_eye_gaze_focus_active_ = false;
+    has_logged_eye_gaze_focus_unavailable_ = false;
+    eye_gaze_unavailable_streak_ = 0;
     quadviews_smoothed_focus_yaw_radians_ = 0.0;
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
@@ -4072,6 +4084,9 @@ XrResult OpenXrLayer::CreateEyeGazeResources(XrSession session) {
 
     eye_gaze_resources_ready_ = true;
     eye_gaze_action_set_attached_ = false;
+    has_logged_eye_gaze_focus_active_ = false;
+    has_logged_eye_gaze_focus_unavailable_ = false;
+    eye_gaze_unavailable_streak_ = 0;
     pending_eye_gaze_diagnostics_ = std::max(pending_eye_gaze_diagnostics_, 120u);
     pending_eye_gaze_sync_diagnostics_ = std::max(pending_eye_gaze_sync_diagnostics_, 20u);
     pending_quadviews_compositor_diagnostics_ = std::max(pending_quadviews_compositor_diagnostics_, 30u);
@@ -4092,6 +4107,9 @@ void OpenXrLayer::DestroyEyeGazeResources() {
     eye_gaze_pose_path_ = XR_NULL_PATH;
     eye_gaze_resources_ready_ = false;
     eye_gaze_action_set_attached_ = false;
+    has_logged_eye_gaze_focus_active_ = false;
+    has_logged_eye_gaze_focus_unavailable_ = false;
+    eye_gaze_unavailable_streak_ = 0;
     quadviews_smoothed_focus_yaw_radians_ = 0.0;
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
@@ -4120,6 +4138,19 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
     *yaw_radians = 0.0;
     *pitch_radians = 0.0;
     auto log_eye_gaze_diagnostic = [&](const std::string& reason) {
+        if (settings.tracking_mode == QuadViewsTrackingMode::Eye && !has_logged_eye_gaze_focus_unavailable_) {
+            // Debounce: require the gaze to stay unavailable for several frames
+            // before declaring it lost, so a single-frame dropout (a blink) does
+            // not produce an unavailable/active churn pair in the log.
+            ++eye_gaze_unavailable_streak_;
+            if (eye_gaze_unavailable_streak_ >= kEyeGazeUnavailableLogThreshold) {
+                logger_.Info("Quadviews eye-gaze focus unavailable; using head/static focus offsets. reason=" + reason +
+                             ", resourcesReady=" + std::to_string(eye_gaze_resources_ready_) +
+                             ", actionSetAttached=" + std::to_string(eye_gaze_action_set_attached_));
+                has_logged_eye_gaze_focus_unavailable_ = true;
+                has_logged_eye_gaze_focus_active_ = false;
+            }
+        }
         if (settings.tracking_mode == QuadViewsTrackingMode::Eye && pending_eye_gaze_diagnostics_ > 0) {
             logger_.Debug("Quadviews eye-gaze focus unavailable: " + reason +
                           ", resourcesReady=" + std::to_string(eye_gaze_resources_ready_) +
@@ -4243,6 +4274,19 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
                       FormatDiagnosticDouble(gaze_ray_angles.forward.z) + ")" +
                       ", baseSpace=" + std::string(gaze_base_space == internal_view_space_ ? "view" : "app"));
         --pending_eye_gaze_diagnostics_;
+    }
+    // Gaze recovered this frame; clear the unavailable streak so a future
+    // dropout must persist past the debounce threshold again before it logs.
+    eye_gaze_unavailable_streak_ = 0;
+    if (!has_logged_eye_gaze_focus_active_) {
+        logger_.Info("Quadviews eye-gaze focus active; using gaze-relative focus offsets. rawYaw=" +
+                     FormatDiagnosticDouble(target_yaw) +
+                     ", rawPitch=" + FormatDiagnosticDouble(target_pitch) +
+                     ", smoothedYaw=" + FormatDiagnosticDouble(*yaw_radians) +
+                     ", smoothedPitch=" + FormatDiagnosticDouble(*pitch_radians) +
+                     ", baseSpace=" + std::string(gaze_base_space == internal_view_space_ ? "view" : "app"));
+        has_logged_eye_gaze_focus_active_ = true;
+        has_logged_eye_gaze_focus_unavailable_ = false;
     }
     return true;
 }


### PR DESCRIPTION
## Summary
Delivers the Quadviews focus region at full resolution end-to-end for a noticeably sharper image, turns on focus 
sharpening by default, retunes the default Quadviews profile, and adds deeper debug logging for focus resolution and eye tracking.

### Changes:

- Fixed the Quadviews focus region being downscaled during compositing. The high-resolution focus view is now delivered at full 1:1 resolution, restoring sharpness that was previously lost and making the Focus Scale setting effective
- Dev Note: You may need to retune your Quadviews settings following this update. Previously, the Foveated Resolution setting was capped at 100%. Values above 100% will now apply correctly!
- Focus sharpening now works correctly and is enabled by default, with edge clamping to avoid halos on high-contrast detail such as cockpit text and instruments. Further changes may be made here based on user feedback.
- Retuned the default Quadviews profile with a larger focus region and lighter peripheral resolution for a sharper, more forgiving image out of the box at roughly a third of full-stereo pixel cost.
- Added detailed Quadviews debug logging, including a focus sampling ratio and canvas density to confirm 1:1 focus rendering, plus eye-tracking interaction-profile diagnostics to help pinpoint why gaze-driven focus may be unavailable.
- Added a subtle update indicator next to the version number that appears when a newer release is available on GitHub, linking to the About page for details.