### PR TITLE
release: VectorXR 0.13.0 performance and runtime hardening

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.12.3",
+      "version": "0.13.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.12.3",
+  "version": "0.13.0",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.12.3"
+version = "0.13.0"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -645,6 +645,12 @@ struct RuntimePacingObservation {
     #[serde(default)]
     runtime_version: String,
     #[serde(default)]
+    system_name: String,
+    #[serde(default)]
+    vendor_id: u32,
+    #[serde(default)]
+    graphics_api: String,
+    #[serde(default)]
     mode: String,
     #[serde(default)]
     source: String,

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/components/QuadViewsSettingsFields.vue
+++ b/app/src/components/QuadViewsSettingsFields.vue
@@ -4,13 +4,74 @@ import type { QuadViewsSettings } from '../lib/model'
 // Shared Quadviews settings editor used by both the Default Profile and each
 // custom profile, so the two stay visually and structurally identical.
 // Fields mutate the passed-in reactive `settings` object directly.
-defineProps<{
+const props = defineProps<{
   settings: QuadViewsSettings
 }>()
+
+type QuadViewsPreset = 'performance' | 'balanced' | 'quality'
+
+const presets: Record<QuadViewsPreset, Pick<QuadViewsSettings,
+  'focusHorizontalSizePercent' | 'focusVerticalSizePercent' | 'focusScale' |
+  'peripheralScale' | 'foveateSharpness' | 'transitionThicknessPercent'>> = {
+  performance: {
+    focusHorizontalSizePercent: 35,
+    focusVerticalSizePercent: 35,
+    focusScale: 1,
+    peripheralScale: 0.3,
+    foveateSharpness: 55,
+    transitionThicknessPercent: 20,
+  },
+  balanced: {
+    focusHorizontalSizePercent: 40,
+    focusVerticalSizePercent: 40,
+    focusScale: 1.1,
+    peripheralScale: 0.35,
+    foveateSharpness: 50,
+    transitionThicknessPercent: 25,
+  },
+  quality: {
+    focusHorizontalSizePercent: 45,
+    focusVerticalSizePercent: 45,
+    focusScale: 1.15,
+    peripheralScale: 0.5,
+    foveateSharpness: 45,
+    transitionThicknessPercent: 25,
+  },
+}
+
+function applyPreset(preset: QuadViewsPreset) {
+  Object.assign(props.settings, presets[preset])
+}
+
+function presetActive(preset: QuadViewsPreset) {
+  return Object.entries(presets[preset]).every(
+    ([key, value]) => props.settings[key as keyof QuadViewsSettings] === value,
+  )
+}
 </script>
 
 <template>
-  <div class="grid gap-3 lg:grid-cols-3">
+  <div class="space-y-3">
+    <div class="flex flex-wrap items-center justify-between gap-3 rounded-[1rem] border px-4 py-3 surface-panel-soft">
+      <div>
+        <p class="eyebrow text-xs uppercase tracking-[0.18em]">Vector Preset</p>
+        <p class="mt-1 text-xs text-muted">A strong starting point; tracking and alignment remain yours.</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="preset in (['performance', 'balanced', 'quality'] as QuadViewsPreset[])"
+          :key="preset"
+          class="rounded-[0.65rem] border px-3 py-1.5 text-xs font-semibold capitalize"
+          :class="presetActive(preset) ? 'button-accent' : 'button-secondary'"
+          type="button"
+          @click="applyPreset(preset)"
+        >
+          {{ preset }}
+        </button>
+      </div>
+    </div>
+
+    <div class="grid gap-3 lg:grid-cols-3">
     <div class="rounded-[1rem] border p-4 surface-panel-soft">
       <p class="eyebrow text-xs uppercase tracking-[0.18em]">Focus Window</p>
       <div class="mt-3 grid gap-3 sm:grid-cols-2">
@@ -231,6 +292,7 @@ defineProps<{
           />
         </label>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/app/src/components/TurboDiagnosticsPage.vue
+++ b/app/src/components/TurboDiagnosticsPage.vue
@@ -1,0 +1,362 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+
+import ModuleBindingPage from './ModuleBindingPage.vue'
+import ModuleBindingPanel from './ModuleBindingPanel.vue'
+import type { TurboMetricsBucket, TurboMetricsSession, VectorXRConfig } from '../lib/model'
+
+const props = defineProps<{
+  config: VectorXRConfig
+  turboMetrics: TurboMetricsSession[]
+}>()
+
+const emit = defineEmits<{
+  close: []
+  clearTurboMetrics: []
+}>()
+
+const metricsBindingOpen = ref(false)
+const selectedSessionId = ref('')
+let savedScrollTop = 0
+
+function pageScroller(): Element | null {
+  return document.querySelector('main section.overflow-y-auto')
+}
+
+function openMetricsBinding() {
+  savedScrollTop = pageScroller()?.scrollTop ?? 0
+  metricsBindingOpen.value = true
+  void nextTick(() => pageScroller()?.scrollTo({ top: 0 }))
+}
+
+function closeMetricsBinding() {
+  metricsBindingOpen.value = false
+  void nextTick(() => pageScroller()?.scrollTo({ top: savedScrollTop }))
+}
+
+const selectedSession = computed<TurboMetricsSession | null>(() => {
+  if (props.turboMetrics.length === 0) {
+    return null
+  }
+  return props.turboMetrics.find((session) => session.sessionId === selectedSessionId.value) ?? props.turboMetrics[0]
+})
+
+function formatSessionLabel(session: TurboMetricsSession): string {
+  const when = session.startedUnixSeconds
+    ? new Date(session.startedUnixSeconds * 1000).toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : 'Unknown time'
+  const runtime = session.runtimeName ? ` · ${session.runtimeName}` : ''
+  return `${when} — ${session.appName || 'unknown app'}${runtime}${session.live ? ' (live)' : ''}`
+}
+
+function bucketLabel(state: string): string {
+  if (state === 'off') {
+    return 'Turbo off'
+  }
+  if (state === 'async') {
+    return 'Turbo — async'
+  }
+  if (state === 'sequenced') {
+    return 'Turbo — sequenced'
+  }
+  return state
+}
+
+function formatSeconds(seconds: number): string {
+  if (seconds >= 90) {
+    const minutes = Math.floor(seconds / 60)
+    const rest = Math.round(seconds % 60)
+    return `${minutes}m ${rest}s`
+  }
+  return `${seconds.toFixed(0)}s`
+}
+
+function onePercentLowFps(bucket: TurboMetricsBucket): string {
+  return bucket.p99FrameMs > 0 ? (1000 / bucket.p99FrameMs).toFixed(1) : '—'
+}
+
+const bucketOrder: Record<string, number> = { off: 0, async: 1, sequenced: 2 }
+
+const selectedBuckets = computed<TurboMetricsBucket[]>(() => {
+  const session = selectedSession.value
+  if (!session) {
+    return []
+  }
+  return [...session.buckets]
+    .filter((bucket) => bucket.frames > 0)
+    .sort((lhs, rhs) => (bucketOrder[lhs.state] ?? 9) - (bucketOrder[rhs.state] ?? 9))
+})
+
+const comparisonMinSeconds = 30
+
+interface MetricsComparison {
+  label: string
+  offFps: number
+  turboFps: number
+  deltaPercent: number
+}
+
+const comparisons = computed<MetricsComparison[]>(() => {
+  const buckets = selectedBuckets.value
+  const off = buckets.find((bucket) => bucket.state === 'off')
+  if (!off || off.seconds < comparisonMinSeconds || off.avgFps <= 0) {
+    return []
+  }
+  return buckets
+    .filter((bucket) => bucket.state !== 'off' && bucket.seconds >= comparisonMinSeconds && bucket.avgFps > 0)
+    .map((bucket) => ({
+      label: bucketLabel(bucket.state),
+      offFps: off.avgFps,
+      turboFps: bucket.avgFps,
+      deltaPercent: ((bucket.avgFps - off.avgFps) / off.avgFps) * 100,
+    }))
+})
+
+function formatDeltaPercent(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`
+}
+
+function comparisonTone(value: number): string {
+  if (value >= 1) {
+    return 'chip-success'
+  }
+  if (value <= -1) {
+    return 'chip-warning'
+  }
+  return 'surface-panel-strong'
+}
+
+function comparisonVerdict(value: number): string {
+  if (value >= 1) {
+    return 'Faster'
+  }
+  if (value <= -1) {
+    return 'Slower'
+  }
+  return 'Within 1%'
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && !metricsBindingOpen.value) {
+    emit('close')
+  }
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <ModuleBindingPage
+    v-if="metricsBindingOpen"
+    module-label="Turbo Diagnostics"
+    :binding="config.modules.turbo.metricsBinding"
+    label="Metrics Capture Binding"
+    description="Start and stop metric collection while in-game. Arm it once you are actually flying and pause it before loading screens or menus, so the recorded numbers reflect real play."
+    none-text="No binding assigned. In capture-binding mode, no metrics are recorded until a binding is set."
+    default-activate-sound="metrics-on.wav"
+    default-deactivate-sound="metrics-off.wav"
+    @update:binding="config.modules.turbo.metricsBinding = $event"
+    @close="closeMetricsBinding"
+  />
+  <div v-else class="space-y-4">
+    <article class="rounded-[1.25rem] border p-5 shadow-panel backdrop-blur surface-panel">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <nav class="flex items-center gap-1.5 text-xs text-muted" aria-label="Breadcrumb">
+            <button class="underline-offset-2 hover:underline" type="button" @click="$emit('close')">Turbo</button>
+            <span aria-hidden="true">›</span>
+            <span class="font-medium" style="color: var(--app-text)">Performance Diagnostics</span>
+          </nav>
+          <h2 class="mt-2 text-2xl font-semibold tracking-tight">Performance Diagnostics</h2>
+          <p class="mt-1 max-w-3xl text-sm leading-6 text-muted">
+            Measure Turbo in the scenario that matters to you. VectorXR compares Turbo on and off only after both sides have enough in-game capture time.
+          </p>
+        </div>
+        <button
+          class="button-secondary inline-flex h-9 w-9 items-center justify-center rounded-[0.75rem]"
+          type="button"
+          aria-label="Close diagnostics and return to Turbo"
+          @click="$emit('close')"
+        >
+          <svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M5.3 5.3a1 1 0 0 1 1.4 0L10 8.6l3.3-3.3a1 1 0 1 1 1.4 1.4L11.4 10l3.3 3.3a1 1 0 0 1-1.4 1.4L10 11.4l-3.3 3.3a1 1 0 0 1-1.4-1.4L8.6 10 5.3 6.7a1 1 0 0 1 0-1.4Z" />
+          </svg>
+        </button>
+      </div>
+
+      <section class="mt-5 rounded-[1rem] border p-4 surface-panel-soft">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div class="max-w-2xl">
+            <p class="text-sm font-semibold tracking-tight">Capture behavior</p>
+            <p class="mt-1 text-sm leading-6 text-muted">
+              Capture only representative gameplay for the fairest result. Loading screens and menus can overwhelm the effect you are trying to measure.
+            </p>
+          </div>
+          <label class="flex items-center gap-3 text-sm font-medium">
+            Collection
+            <select
+              v-model="config.modules.turbo.metricsMode"
+              class="rounded-[0.6rem] border px-3 py-1.5 text-sm surface-panel-strong"
+              style="border-color: var(--app-border)"
+            >
+              <option value="always">Always while in-game</option>
+              <option value="binding">Use a capture binding</option>
+              <option value="off">Off</option>
+            </select>
+          </label>
+        </div>
+
+        <p class="mt-3 text-xs leading-5 text-muted">
+          <template v-if="config.modules.turbo.metricsMode === 'binding'">
+            Recording starts and pauses with your capture binding. This is the recommended mode for controlled comparisons.
+          </template>
+          <template v-else-if="config.modules.turbo.metricsMode === 'always'">
+            Recording runs whenever Turbo applies. Hitches over one second are excluded, but menus and loading screens still count.
+          </template>
+          <template v-else>
+            Metrics collection is disabled. Existing results remain available below.
+          </template>
+        </p>
+
+        <ModuleBindingPanel
+          v-if="config.modules.turbo.metricsMode === 'binding'"
+          class="mt-3"
+          heading="Metrics Capture Binding"
+          :binding="config.modules.turbo.metricsBinding"
+          hint="Arm capture once you are actually flying; pause it before loading screens or menus."
+          @edit="openMetricsBinding"
+        />
+      </section>
+
+      <section class="mt-5 border-t pt-5" style="border-color: var(--app-border)">
+        <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Results</p>
+            <p class="mt-1 text-sm text-muted">Choose a flight, read the verdict, then open the detailed measurements only if you need them.</p>
+          </div>
+          <button
+            v-if="turboMetrics.length > 0"
+            class="button-secondary rounded-[0.6rem] px-3 py-1.5 text-xs"
+            type="button"
+            title="Delete all recorded metric sessions"
+            @click="emit('clearTurboMetrics')"
+          >
+            Clear all results
+          </button>
+        </div>
+
+        <div v-if="turboMetrics.length === 0" class="rounded-[0.9rem] border border-dashed px-5 py-6 text-center surface-panel-soft">
+          <p class="text-sm font-medium">No performance checks yet</p>
+          <p class="mt-1 text-sm text-muted">Run Turbo in a game and results will update here about every 15 seconds.</p>
+        </div>
+
+        <template v-else>
+          <label class="mb-4 flex flex-wrap items-center gap-2 text-sm font-medium">
+            Flight
+            <select
+              :value="selectedSession?.sessionId ?? ''"
+              class="min-w-0 max-w-full rounded-[0.6rem] border px-3 py-1.5 text-sm surface-panel-strong"
+              style="border-color: var(--app-border)"
+              @change="selectedSessionId = ($event.target as HTMLSelectElement).value"
+            >
+              <option v-for="session in turboMetrics" :key="session.sessionId" :value="session.sessionId">
+                {{ formatSessionLabel(session) }}
+              </option>
+            </select>
+          </label>
+
+          <div v-if="comparisons.length > 0" class="grid gap-3 md:grid-cols-2">
+            <article
+              v-for="comparison in comparisons"
+              :key="comparison.label"
+              class="rounded-[1rem] border p-4"
+              :class="comparisonTone(comparison.deltaPercent)"
+              style="border-color: var(--app-border)"
+            >
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <span class="text-xs font-semibold uppercase tracking-[0.18em]">{{ comparisonVerdict(comparison.deltaPercent) }}</span>
+                <span class="rounded-full border px-2.5 py-1 text-xs" style="border-color: var(--app-border)">{{ comparison.label }}</span>
+              </div>
+              <p class="mt-3 text-3xl font-semibold tracking-tight">{{ formatDeltaPercent(comparison.deltaPercent) }}</p>
+              <p class="mt-1 text-sm">Average fps versus Turbo off</p>
+              <p class="mt-3 text-xs text-muted">{{ comparison.offFps.toFixed(1) }} → {{ comparison.turboFps.toFixed(1) }} fps in this flight</p>
+            </article>
+          </div>
+
+          <div v-else class="rounded-[1rem] border px-4 py-4 surface-panel-strong">
+            <p class="text-sm font-semibold">More comparable flight time needed</p>
+            <p class="mt-1 text-sm leading-6 text-muted">
+              Capture at least 30 seconds with Turbo off and 30 seconds with Turbo on in similar conditions. Use the Turbo toggle between passes.
+            </p>
+            <div v-if="selectedBuckets.length > 0" class="mt-3 flex flex-wrap gap-2">
+              <span v-for="bucket in selectedBuckets" :key="bucket.state" class="rounded-full border px-3 py-1 text-xs" style="border-color: var(--app-border)">
+                {{ bucketLabel(bucket.state) }} · {{ formatSeconds(bucket.seconds) }}
+              </span>
+            </div>
+          </div>
+
+          <p v-if="comparisons.length > 0" class="mt-3 text-xs leading-5 text-muted">
+            Use the percentage as evidence, not a promise: scene complexity, weather, traffic, and background work still affect the comparison.
+          </p>
+
+          <details class="section-disclosure mt-5 border-t pt-4" style="border-color: var(--app-border)">
+            <summary class="flex items-center gap-2">
+              <svg aria-hidden="true" class="section-chevron h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M7.2 14.8a1 1 0 0 1 0-1.4L10.6 10 7.2 6.6a1 1 0 1 1 1.4-1.4l4.1 4.1a1 1 0 0 1 0 1.4l-4.1 4.1a1 1 0 0 1-1.4 0Z" clip-rule="evenodd" />
+              </svg>
+              <span class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Detailed Measurements</span>
+              <span class="text-xs text-muted">Frame times, runtime wait, and stalls</span>
+            </summary>
+
+            <div v-if="selectedBuckets.length === 0" class="mt-3 rounded-[0.9rem] border border-dashed px-4 py-4 text-sm text-muted surface-panel-soft">
+              This flight has no captured frames yet.
+            </div>
+            <div v-else class="mt-3 overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs uppercase tracking-wide text-muted">
+                    <th class="py-2 pr-3 font-medium">Pacing</th>
+                    <th class="py-2 pr-3 font-medium">Time</th>
+                    <th class="py-2 pr-3 font-medium">Avg fps</th>
+                    <th class="py-2 pr-3 font-medium">1% low</th>
+                    <th class="py-2 pr-3 font-medium">Avg frame</th>
+                    <th class="py-2 pr-3 font-medium">p99 frame</th>
+                    <th class="py-2 pr-3 font-medium" title="Average per-frame time the game spent blocked on runtime pacing">Wait blocked</th>
+                    <th class="py-2 font-medium" title="Frame-pacing stalls counted by the safety circuit">Stalls</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="bucket in selectedBuckets" :key="bucket.state" class="border-t" style="border-color: var(--app-border)">
+                    <td class="py-2.5 pr-3 font-medium">{{ bucketLabel(bucket.state) }}</td>
+                    <td class="py-2.5 pr-3 text-muted">{{ formatSeconds(bucket.seconds) }}</td>
+                    <td class="py-2.5 pr-3">{{ bucket.avgFps.toFixed(1) }}</td>
+                    <td class="py-2.5 pr-3">{{ onePercentLowFps(bucket) }}</td>
+                    <td class="py-2.5 pr-3">{{ bucket.avgFrameMs.toFixed(2) }} ms</td>
+                    <td class="py-2.5 pr-3">{{ bucket.p99FrameMs.toFixed(2) }} ms</td>
+                    <td class="py-2.5 pr-3">{{ bucket.avgWaitBlockMs.toFixed(2) }} ms</td>
+                    <td class="py-2.5">{{ bucket.drainTimeouts }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p v-if="selectedSession" class="mt-2 text-xs text-muted">
+              {{ selectedSession.live ? 'Flight in progress — updates every ~15 seconds.' : 'Flight complete.' }}
+              Collection: {{ selectedSession.collectionMode === 'binding' ? 'capture binding' : 'always' }}.
+              <template v-if="selectedBuckets.some((bucket) => bucket.discardedFrames > 0)">Hitches over one second were excluded.</template>
+            </p>
+          </details>
+        </template>
+      </section>
+
+      <div class="mt-5 flex justify-end border-t pt-4" style="border-color: var(--app-border)">
+        <button class="button-accent rounded-[0.75rem] px-6 py-2.5 text-sm font-medium" type="button" @click="$emit('close')">Done</button>
+      </div>
+    </article>
+  </div>
+</template>

--- a/app/src/components/TurboRuntimePage.vue
+++ b/app/src/components/TurboRuntimePage.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+
+import type { ActiveRuntimeInfo } from '../lib/commands'
+import type { RuntimePacingObservation, TurboPacingMode, VectorXRConfig } from '../lib/model'
+
+const props = defineProps<{
+  config: VectorXRConfig
+  runtimePacing: RuntimePacingObservation[]
+  activeRuntime: ActiveRuntimeInfo | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  rediscoverRuntime: [runtimeName: string]
+}>()
+
+const pacingForced = computed(() => props.config.modules.turbo.pacingMode !== 'auto')
+
+interface PacingRow {
+  runtimeName: string
+  runtimeVersion: string
+  systemName: string
+  vendorId: number
+  graphicsApi: string
+  mode: RuntimePacingObservation['mode'] | null
+  source: RuntimePacingObservation['source'] | null
+  lastUsedUnixSeconds: number
+  isActive: boolean
+}
+
+const genericTokens = new Set(['openxr', 'runtime', 'windows', 'program', 'files'])
+
+function matchesActiveRuntime(runtimeName: string): boolean {
+  const active = props.activeRuntime
+  if (!active) {
+    return false
+  }
+  const name = runtimeName.toLowerCase()
+  if (active.name) {
+    const activeName = active.name.toLowerCase()
+    if (activeName.includes(name) || name.includes(activeName)) {
+      return true
+    }
+  }
+  const normalizedPath = active.manifestPath.toLowerCase().replace(/[^a-z0-9]+/g, '')
+  return runtimeName
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4 && !genericTokens.has(token))
+    .some((token) => normalizedPath.includes(token))
+}
+
+const pacingRows = computed<PacingRow[]>(() => {
+  const rows: PacingRow[] = props.runtimePacing.map((observation) => ({
+    runtimeName: observation.runtimeName,
+    runtimeVersion: observation.runtimeVersion,
+    systemName: observation.systemName,
+    vendorId: observation.vendorId,
+    graphicsApi: observation.graphicsApi,
+    mode: observation.mode,
+    source: observation.source,
+    lastUsedUnixSeconds: observation.lastUsedUnixSeconds,
+    isActive: matchesActiveRuntime(observation.runtimeName),
+  }))
+
+  for (const runtimeName of Object.keys(props.config.modules.turbo.runtimePins)) {
+    if (!rows.some((row) => row.runtimeName === runtimeName)) {
+      rows.push({
+        runtimeName,
+        runtimeVersion: '',
+        systemName: '',
+        vendorId: 0,
+        graphicsApi: '',
+        mode: null,
+        source: null,
+        lastUsedUnixSeconds: 0,
+        isActive: matchesActiveRuntime(runtimeName),
+      })
+    }
+  }
+
+  return rows.sort((lhs, rhs) => rhs.lastUsedUnixSeconds - lhs.lastUsedUnixSeconds)
+})
+
+const activeRuntimeLabel = computed(() => {
+  const active = props.activeRuntime
+  if (!active) {
+    return ''
+  }
+  if (active.name) {
+    return active.name
+  }
+  const file = active.manifestPath.split(/[\\/]/).pop() ?? ''
+  return file.replace(/\.json$/i, '')
+})
+
+const activeRuntimeHasRow = computed(() => pacingRows.value.some((row) => row.isActive))
+
+function pinValue(runtimeName: string): TurboPacingMode | 'auto' {
+  return props.config.modules.turbo.runtimePins[runtimeName] ?? 'auto'
+}
+
+function setPin(runtimeName: string, value: string) {
+  const pins = props.config.modules.turbo.runtimePins
+  if (value === 'async' || value === 'sequenced') {
+    pins[runtimeName] = value
+  } else {
+    delete pins[runtimeName]
+  }
+}
+
+function rowModeLabel(row: PacingRow): string {
+  const pinned = props.config.modules.turbo.runtimePins[row.runtimeName]
+  if (pinned) {
+    return pinned === 'async' ? 'Async' : 'Sequenced'
+  }
+  if (row.mode === 'async') {
+    return 'Async'
+  }
+  if (row.mode === 'sequenced') {
+    return 'Sequenced'
+  }
+  if (row.mode === 'unsupported') {
+    return 'Not supported'
+  }
+  return 'Undiscovered'
+}
+
+function rowBadge(row: PacingRow): string {
+  if (props.config.modules.turbo.runtimePins[row.runtimeName]) {
+    return 'Pinned'
+  }
+  if (row.mode === 'unsupported') {
+    return 'Suspended'
+  }
+  if (row.source === 'preset') {
+    return 'Preset'
+  }
+  if (row.source === 'discovered') {
+    return 'Discovered'
+  }
+  return ''
+}
+
+function formatDate(unixSeconds: number): string {
+  return unixSeconds ? new Date(unixSeconds * 1000).toLocaleDateString() : '—'
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    emit('close')
+  }
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <div class="space-y-4">
+    <article class="rounded-[1.25rem] border p-5 shadow-panel backdrop-blur surface-panel">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <nav class="flex items-center gap-1.5 text-xs text-muted" aria-label="Breadcrumb">
+            <button class="underline-offset-2 hover:underline" type="button" @click="$emit('close')">Turbo</button>
+            <span aria-hidden="true">›</span>
+            <span class="font-medium" style="color: var(--app-text)">Runtime Behavior</span>
+          </nav>
+          <h2 class="mt-2 text-2xl font-semibold tracking-tight">Runtime Behavior</h2>
+          <p class="mt-1 max-w-3xl text-sm leading-6 text-muted">
+            Control how Turbo coordinates with each OpenXR runtime. Auto is designed to make this decision for you and is the right choice for almost everyone.
+          </p>
+        </div>
+        <button
+          class="button-secondary inline-flex h-9 w-9 items-center justify-center rounded-[0.75rem]"
+          type="button"
+          aria-label="Close runtime behavior and return to Turbo"
+          @click="$emit('close')"
+        >
+          <svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M5.3 5.3a1 1 0 0 1 1.4 0L10 8.6l3.3-3.3a1 1 0 1 1 1.4 1.4L11.4 10l3.3 3.3a1 1 0 0 1-1.4 1.4L10 11.4l-3.3 3.3a1 1 0 0 1-1.4-1.4L8.6 10 5.3 6.7a1 1 0 0 1 0-1.4Z" />
+          </svg>
+        </button>
+      </div>
+
+      <section class="mt-5 rounded-[1rem] border p-4 surface-panel-soft">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div class="max-w-2xl">
+            <p class="text-sm font-semibold tracking-tight">Pacing strategy</p>
+            <p class="mt-1 text-sm leading-6 text-muted">
+              Auto tests the safe strategy, remembers the result for this runtime and headset, and adapts if the runtime cannot keep pace.
+            </p>
+          </div>
+          <label class="flex items-center gap-3 text-sm font-medium">
+            Mode
+            <select
+              v-model="config.modules.turbo.pacingMode"
+              class="rounded-[0.6rem] border px-3 py-1.5 text-sm surface-panel-strong"
+              style="border-color: var(--app-border)"
+            >
+              <option value="auto">Auto (recommended)</option>
+              <option value="async">Async — always</option>
+              <option value="sequenced">Sequenced — always</option>
+            </select>
+          </label>
+        </div>
+
+        <div
+          class="mt-4 rounded-[0.85rem] border px-4 py-3 text-sm leading-6"
+          :class="pacingForced ? 'chip-warning' : 'chip-success'"
+          style="border-color: var(--app-border)"
+        >
+          <template v-if="!pacingForced">
+            <strong>Automatic protection is active.</strong> Async overlaps the runtime wait with game work; Sequenced supports runtimes that require wait and submission to remain interlocked.
+          </template>
+          <template v-else>
+            <strong>Manual override is active.</strong> This strategy is forced on every runtime. Discovery and per-runtime decisions below are paused, and Turbo suspends itself if the runtime cannot keep pace.
+          </template>
+        </div>
+      </section>
+
+      <section class="mt-5 border-t pt-5" style="border-color: var(--app-border)">
+        <div class="mb-3 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Runtime Decisions</p>
+            <p class="mt-1 text-sm leading-6 text-muted">Review what Auto learned or override one runtime without affecting the rest.</p>
+          </div>
+          <span v-if="activeRuntimeLabel" class="rounded-full border px-3 py-1 text-xs text-muted" style="border-color: var(--app-border)">
+            Active: <span class="font-medium" style="color: var(--app-text)">{{ activeRuntimeLabel }}</span>
+          </span>
+        </div>
+
+        <div v-if="pacingRows.length === 0" class="rounded-[0.9rem] border border-dashed px-4 py-5 text-sm text-muted surface-panel-soft">
+          Nothing to manage yet. Auto records a decision after Turbo's first session on a runtime.
+        </div>
+
+        <div v-else class="overflow-x-auto" :class="pacingForced ? 'pointer-events-none opacity-50' : ''">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs uppercase tracking-wide text-muted">
+                <th class="py-2 pr-3 font-medium">Environment</th>
+                <th class="py-2 pr-3 font-medium">Decision</th>
+                <th class="py-2 pr-3 font-medium">Learned</th>
+                <th class="py-2 pr-3 font-medium">Override</th>
+                <th class="py-2 font-medium"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in pacingRows"
+                :key="`${row.runtimeName}|${row.systemName}|${row.vendorId}|${row.graphicsApi}`"
+                class="border-t"
+                style="border-color: var(--app-border)"
+              >
+                <td class="py-3 pr-3">
+                  <span :class="row.isActive ? 'font-semibold' : ''">{{ row.runtimeName }}</span>
+                  <span v-if="row.runtimeVersion" class="ml-1 text-xs text-muted">{{ row.runtimeVersion }}</span>
+                  <span v-if="row.isActive" class="ml-2 rounded-full border px-2 py-0.5 text-[0.65rem] uppercase tracking-wide" style="border-color: var(--app-border)">Active</span>
+                  <span v-if="row.systemName || row.graphicsApi" class="mt-0.5 block text-xs text-muted">
+                    {{ row.systemName || 'Unknown headset' }}<template v-if="row.graphicsApi"> · {{ row.graphicsApi }}</template>
+                  </span>
+                </td>
+                <td class="py-3 pr-3">
+                  <span class="font-medium">{{ rowModeLabel(row) }}</span>
+                  <span v-if="rowBadge(row)" class="ml-2 rounded-full border px-2 py-0.5 text-xs" style="border-color: var(--app-border)">{{ rowBadge(row) }}</span>
+                </td>
+                <td class="py-3 pr-3 text-muted">{{ formatDate(row.lastUsedUnixSeconds) }}</td>
+                <td class="py-3 pr-3">
+                  <select
+                    :value="pinValue(row.runtimeName)"
+                    class="rounded-[0.5rem] border px-2 py-1 text-xs surface-panel-strong"
+                    style="border-color: var(--app-border)"
+                    @change="setPin(row.runtimeName, ($event.target as HTMLSelectElement).value)"
+                  >
+                    <option value="auto">Use Auto</option>
+                    <option value="async">Pin Async</option>
+                    <option value="sequenced">Pin Sequenced</option>
+                  </select>
+                </td>
+                <td class="py-3 text-right">
+                  <button
+                    v-if="row.source"
+                    class="button-secondary rounded-[0.5rem] px-2.5 py-1 text-xs"
+                    type="button"
+                    title="Forget this decision so Auto tests the runtime again"
+                    @click="emit('rediscoverRuntime', row.runtimeName)"
+                  >
+                    Test again
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p v-if="pacingForced && pacingRows.length > 0" class="mt-2 text-xs text-muted">
+          Runtime decisions are inactive while a global manual override is selected.
+        </p>
+        <p v-else-if="activeRuntimeLabel && !activeRuntimeHasRow && pacingRows.length > 0" class="mt-2 text-xs text-muted">
+          Auto will test {{ activeRuntimeLabel }} during the next Turbo session.
+        </p>
+      </section>
+
+      <div class="mt-5 flex justify-end border-t pt-4" style="border-color: var(--app-border)">
+        <button class="button-accent rounded-[0.75rem] px-6 py-2.5 text-sm font-medium" type="button" @click="$emit('close')">Done</button>
+      </div>
+    </article>
+  </div>
+</template>

--- a/app/src/components/tabs/QuadViewsTab.vue
+++ b/app/src/components/tabs/QuadViewsTab.vue
@@ -69,7 +69,7 @@ function estimatedPixelBudget(settings: QuadViewsSettings) {
 }
 
 function budgetLabel(settings: QuadViewsSettings) {
-  return `${estimatedPixelBudget(settings).toFixed(1)}% of stereo pixels`;
+  return `${estimatedPixelBudget(settings).toFixed(1)}% estimated app render pixels`;
 }
 
 type BudgetTone = "light" | "moderate" | "heavy" | "detrimental";
@@ -130,7 +130,10 @@ function budgetChipClass(settings: QuadViewsSettings) {
             foveal and peripheral rendering.
           </p>
           <p class="mt-2 max-w-3xl text-sm font-bold leading-6 text-muted">
-          Experimental - DX11 OpenXR applications only!
+          Emulated Quadviews currently supports D3D11 OpenXR applications. Native Varjo quadviews remains runtime-driven.
+          </p>
+          <p class="mt-1 max-w-3xl text-xs leading-5 text-muted">
+            Pixel estimates compare application view rendering only; the runtime and VectorXR composite have additional GPU cost.
           </p>
         </div>
         <button

--- a/app/src/components/tabs/QuadViewsTab.vue
+++ b/app/src/components/tabs/QuadViewsTab.vue
@@ -119,11 +119,6 @@ function budgetChipClass(settings: QuadViewsSettings) {
         <div>
           <div class="flex flex-wrap items-center gap-3">
             <h2 class="text-2xl font-semibold tracking-tight">Quadviews</h2>
-            <span
-              class="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] chip-warning"
-            >
-              ⚠ Experimental
-            </span>
           </div>
           <p class="mt-2 max-w-3xl text-sm leading-6 text-muted">
             Manage native quadview defaults and per-application profiles for

--- a/app/src/components/tabs/TurboTab.vue
+++ b/app/src/components/tabs/TurboTab.vue
@@ -58,6 +58,9 @@ const toolkitConflict = computed(() => {
 interface PacingRow {
   runtimeName: string
   runtimeVersion: string
+  systemName: string
+  vendorId: number
+  graphicsApi: string
   mode: RuntimePacingObservation['mode'] | null
   source: RuntimePacingObservation['source'] | null
   lastUsedUnixSeconds: number
@@ -92,6 +95,9 @@ const pacingRows = computed<PacingRow[]>(() => {
   const rows: PacingRow[] = props.runtimePacing.map((observation) => ({
     runtimeName: observation.runtimeName,
     runtimeVersion: observation.runtimeVersion,
+    systemName: observation.systemName,
+    vendorId: observation.vendorId,
+    graphicsApi: observation.graphicsApi,
     mode: observation.mode,
     source: observation.source,
     lastUsedUnixSeconds: observation.lastUsedUnixSeconds,
@@ -103,6 +109,9 @@ const pacingRows = computed<PacingRow[]>(() => {
       rows.push({
         runtimeName,
         runtimeVersion: '',
+        systemName: '',
+        vendorId: 0,
+        graphicsApi: '',
         mode: null,
         source: null,
         lastUsedUnixSeconds: 0,
@@ -389,13 +398,16 @@ function formatDeltaPercent(value: number): string {
             <tbody>
               <tr
                 v-for="row in pacingRows"
-                :key="row.runtimeName"
+                :key="`${row.runtimeName}|${row.systemName}|${row.vendorId}|${row.graphicsApi}`"
                 class="border-t"
                 style="border-color: var(--app-border)"
               >
                 <td class="py-2.5 pr-3">
                   <span :class="row.isActive ? 'font-semibold' : ''">{{ row.runtimeName }}</span>
                   <span v-if="row.runtimeVersion" class="ml-1 text-xs text-muted">{{ row.runtimeVersion }}</span>
+                  <span v-if="row.systemName || row.graphicsApi" class="mt-0.5 block text-xs text-muted">
+                    {{ row.systemName || 'Unknown headset' }}<template v-if="row.graphicsApi"> · {{ row.graphicsApi }}</template>
+                  </span>
                   <span
                     v-if="row.isActive"
                     class="ml-2 rounded-full border px-2 py-0.5 text-[0.65rem] uppercase tracking-wide"

--- a/app/src/components/tabs/TurboTab.vue
+++ b/app/src/components/tabs/TurboTab.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 
 import ModuleBindingPage from '../ModuleBindingPage.vue'
 import ModuleBindingPanel from '../ModuleBindingPanel.vue'
 import ProfileShell from '../ProfileShell.vue'
+import TurboDiagnosticsPage from '../TurboDiagnosticsPage.vue'
+import TurboRuntimePage from '../TurboRuntimePage.vue'
 import type { ActiveRuntimeInfo, OpenXrLayerSnapshot } from '../../lib/commands'
 import type {
   RegisteredApplication,
   RuntimePacingObservation,
-  TurboMetricsBucket,
   TurboMetricsSession,
-  TurboPacingMode,
   VectorXRConfig,
 } from '../../lib/model'
 
@@ -33,19 +33,13 @@ const emit = defineEmits<{
 
 const howItWorksOpen = ref(false)
 const bindingSubPageOpen = ref(false)
-const metricsBindingSubPageOpen = ref(false)
+const activeSubPage = ref<'runtime' | 'diagnostics' | null>(null)
+let savedScrollTop = 0
 
-const pacingForced = computed(() => props.config.modules.turbo.pacingMode !== 'auto')
-
-// Turbo counts as "in use" when the default profile is on or any enabled
-// custom profile exists — the advisory should fire for either.
 const turboInUse = computed(
   () => props.config.modules.turbo.enabled || props.config.modules.turbo.profiles.some((profile) => profile.enabled),
 )
 
-// Two frame-pacing layers fight each other: warn when OpenXR Toolkit is
-// enabled anywhere while Turbo applies. (We cannot see whether OXRTK's own
-// turbo is switched on, so this stays an advisory, not an error.)
 const toolkitConflict = computed(() => {
   if (!turboInUse.value) {
     return false
@@ -55,233 +49,69 @@ const toolkitConflict = computed(() => {
   )
 })
 
-interface PacingRow {
-  runtimeName: string
-  runtimeVersion: string
-  systemName: string
-  vendorId: number
-  graphicsApi: string
-  mode: RuntimePacingObservation['mode'] | null
-  source: RuntimePacingObservation['source'] | null
-  lastUsedUnixSeconds: number
-  isActive: boolean
-}
-
-// Generic tokens that appear in nearly every OpenXR manifest path and would
-// make the active-runtime match meaningless.
-const genericTokens = new Set(['openxr', 'runtime', 'windows', 'program', 'files'])
-
-function matchesActiveRuntime(runtimeName: string): boolean {
-  const active = props.activeRuntime
-  if (!active) {
-    return false
+const pacingModeLabel = computed(() => {
+  const mode = props.config.modules.turbo.pacingMode
+  if (mode === 'async') {
+    return 'Forced Async'
   }
-  const name = runtimeName.toLowerCase()
-  if (active.name) {
-    const activeName = active.name.toLowerCase()
-    if (activeName.includes(name) || name.includes(activeName)) {
-      return true
-    }
+  if (mode === 'sequenced') {
+    return 'Forced Sequenced'
   }
-  const normalizedPath = active.manifestPath.toLowerCase().replace(/[^a-z0-9]+/g, '')
-  return runtimeName
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((token) => token.length >= 4 && !genericTokens.has(token))
-    .some((token) => normalizedPath.includes(token))
-}
-
-const pacingRows = computed<PacingRow[]>(() => {
-  const rows: PacingRow[] = props.runtimePacing.map((observation) => ({
-    runtimeName: observation.runtimeName,
-    runtimeVersion: observation.runtimeVersion,
-    systemName: observation.systemName,
-    vendorId: observation.vendorId,
-    graphicsApi: observation.graphicsApi,
-    mode: observation.mode,
-    source: observation.source,
-    lastUsedUnixSeconds: observation.lastUsedUnixSeconds,
-    isActive: matchesActiveRuntime(observation.runtimeName),
-  }))
-  // Pins for runtimes without an observation still deserve a row.
-  for (const runtimeName of Object.keys(props.config.modules.turbo.runtimePins)) {
-    if (!rows.some((row) => row.runtimeName === runtimeName)) {
-      rows.push({
-        runtimeName,
-        runtimeVersion: '',
-        systemName: '',
-        vendorId: 0,
-        graphicsApi: '',
-        mode: null,
-        source: null,
-        lastUsedUnixSeconds: 0,
-        isActive: matchesActiveRuntime(runtimeName),
-      })
-    }
-  }
-  return rows.sort((lhs, rhs) => rhs.lastUsedUnixSeconds - lhs.lastUsedUnixSeconds)
+  return 'Auto'
 })
 
-const activeRuntimeLabel = computed(() => {
-  const active = props.activeRuntime
-  if (!active) {
-    return ''
+const pacingSummary = computed(() => {
+  if (props.config.modules.turbo.pacingMode !== 'auto') {
+    return 'A manual strategy is being used for every runtime.'
   }
-  if (active.name) {
-    return active.name
+  const environments = props.runtimePacing.length
+  if (environments === 0) {
+    return 'VectorXR will choose and remember the safe strategy for each runtime.'
   }
-  const file = active.manifestPath.split(/[\\/]/).pop() ?? ''
-  return file.replace(/\.json$/i, '')
+  return `${environments} runtime ${environments === 1 ? 'environment' : 'environments'} observed. VectorXR adapts each one independently.`
 })
 
-const activeRuntimeHasRow = computed(() => pacingRows.value.some((row) => row.isActive))
-
-function pinValue(runtimeName: string): TurboPacingMode | 'auto' {
-  return props.config.modules.turbo.runtimePins[runtimeName] ?? 'auto'
-}
-
-function setPin(runtimeName: string, value: string) {
-  const pins = props.config.modules.turbo.runtimePins
-  if (value === 'async' || value === 'sequenced') {
-    pins[runtimeName] = value
-  } else {
-    delete pins[runtimeName]
+const metricsModeLabel = computed(() => {
+  const mode = props.config.modules.turbo.metricsMode
+  if (mode === 'binding') {
+    return 'Controlled capture'
   }
-}
-
-function rowModeLabel(row: PacingRow): string {
-  const pinned = props.config.modules.turbo.runtimePins[row.runtimeName]
-  if (pinned) {
-    return pinned === 'async' ? 'Async' : 'Sequenced'
+  if (mode === 'off') {
+    return 'Collection off'
   }
-  if (row.mode === 'async') {
-    return 'Async'
-  }
-  if (row.mode === 'sequenced') {
-    return 'Sequenced'
-  }
-  if (row.mode === 'unsupported') {
-    return 'Not supported'
-  }
-  return 'Undiscovered'
-}
-
-function rowBadge(row: PacingRow): string {
-  if (props.config.modules.turbo.runtimePins[row.runtimeName]) {
-    return 'Pinned'
-  }
-  if (row.mode === 'unsupported') {
-    return 'Suspended'
-  }
-  if (row.source === 'preset') {
-    return 'Preset'
-  }
-  if (row.source === 'discovered') {
-    return 'Discovered'
-  }
-  return ''
-}
-
-function formatDate(unixSeconds: number): string {
-  if (!unixSeconds) {
-    return '—'
-  }
-  return new Date(unixSeconds * 1000).toLocaleDateString()
-}
-
-// --- Session metrics (layer-written turbo-metrics.json) ---
-
-const selectedSessionId = ref('')
-
-// Sessions arrive newest-first; fall back to the newest when nothing (or a
-// since-evicted session) is selected.
-const selectedSession = computed<TurboMetricsSession | null>(() => {
-  if (props.turboMetrics.length === 0) {
-    return null
-  }
-  return props.turboMetrics.find((session) => session.sessionId === selectedSessionId.value) ?? props.turboMetrics[0]
+  return 'Automatic capture'
 })
 
-function formatSessionLabel(session: TurboMetricsSession): string {
-  const when = session.startedUnixSeconds
-    ? new Date(session.startedUnixSeconds * 1000).toLocaleString([], {
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      })
-    : 'Unknown time'
-  const runtime = session.runtimeName ? ` · ${session.runtimeName}` : ''
-  return `${when} — ${session.appName || 'unknown app'}${runtime}${session.live ? ' (live)' : ''}`
-}
-
-function bucketLabel(state: string): string {
-  if (state === 'off') {
-    return 'Turbo off'
+const metricsSummary = computed(() => {
+  const count = props.turboMetrics.length
+  if (count === 0) {
+    return 'Run an in-game A/B check to see whether Turbo helps this title.'
   }
-  if (state === 'async') {
-    return 'Turbo — async'
-  }
-  if (state === 'sequenced') {
-    return 'Turbo — sequenced'
-  }
-  return state
-}
-
-function formatSeconds(seconds: number): string {
-  if (seconds >= 90) {
-    const minutes = Math.floor(seconds / 60)
-    const rest = Math.round(seconds % 60)
-    return `${minutes}m ${rest}s`
-  }
-  return `${seconds.toFixed(0)}s`
-}
-
-function onePercentLowFps(bucket: TurboMetricsBucket): string {
-  return bucket.p99FrameMs > 0 ? (1000 / bucket.p99FrameMs).toFixed(1) : '—'
-}
-
-const bucketOrder: Record<string, number> = { off: 0, async: 1, sequenced: 2 }
-
-const selectedBuckets = computed<TurboMetricsBucket[]>(() => {
-  const session = selectedSession.value
-  if (!session) {
-    return []
-  }
-  return [...session.buckets]
-    .filter((bucket) => bucket.frames > 0)
-    .sort((lhs, rhs) => (bucketOrder[lhs.state] ?? 9) - (bucketOrder[rhs.state] ?? 9))
+  const latest = props.turboMetrics[0]
+  const app = latest.appName || 'unknown app'
+  return `${count} ${count === 1 ? 'flight' : 'flights'} recorded. Latest: ${app}${latest.live ? ' (in progress)' : ''}.`
 })
 
-// Honest comparison gate: both states need meaningful captured time in the
-// same session before an improvement number means anything.
-const kComparisonMinSeconds = 30
-
-interface MetricsComparison {
-  label: string
-  offFps: number
-  turboFps: number
-  deltaPercent: number
+function pageScroller(): Element | null {
+  return document.querySelector('main section.overflow-y-auto')
 }
 
-const comparisons = computed<MetricsComparison[]>(() => {
-  const buckets = selectedBuckets.value
-  const off = buckets.find((bucket) => bucket.state === 'off')
-  if (!off || off.seconds < kComparisonMinSeconds || off.avgFps <= 0) {
-    return []
-  }
-  return buckets
-    .filter((bucket) => bucket.state !== 'off' && bucket.seconds >= kComparisonMinSeconds && bucket.avgFps > 0)
-    .map((bucket) => ({
-      label: bucketLabel(bucket.state),
-      offFps: off.avgFps,
-      turboFps: bucket.avgFps,
-      deltaPercent: ((bucket.avgFps - off.avgFps) / off.avgFps) * 100,
-    }))
-})
+function openSubPage(page: 'runtime' | 'diagnostics') {
+  savedScrollTop = pageScroller()?.scrollTop ?? 0
+  activeSubPage.value = page
+  void nextTick(() => pageScroller()?.scrollTo({ top: 0 }))
+}
 
-function formatDeltaPercent(value: number): string {
-  return `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`
+function openToggleBinding() {
+  savedScrollTop = pageScroller()?.scrollTop ?? 0
+  bindingSubPageOpen.value = true
+  void nextTick(() => pageScroller()?.scrollTo({ top: 0 }))
+}
+
+function closeSubPage() {
+  bindingSubPageOpen.value = false
+  activeSubPage.value = null
+  void nextTick(() => pageScroller()?.scrollTo({ top: savedScrollTop }))
 }
 </script>
 
@@ -291,34 +121,35 @@ function formatDeltaPercent(value: number): string {
     module-label="Turbo"
     :binding="config.modules.turbo.toggleBinding"
     label="Turbo Toggle Binding"
-    description="Flip Turbo on and off while in-game to compare fps and frame feel directly. Turbo starts enabled whenever it applies to the running application. Note: switching Turbo on mid-session can cause a brief hitch while the frame pipeline re-synchronizes."
+    description="Flip Turbo on and off while in-game to compare fps and frame feel directly. Turbo starts enabled whenever it applies to the running application. Switching Turbo on mid-session can cause a brief hitch while the frame pipeline re-synchronizes."
     none-text="No binding assigned. Turbo stays on for applications it applies to."
     default-activate-sound="turbo-on.wav"
     default-deactivate-sound="turbo-off.wav"
     @update:binding="config.modules.turbo.toggleBinding = $event"
-    @close="bindingSubPageOpen = false"
+    @close="closeSubPage"
   />
-  <ModuleBindingPage
-    v-else-if="metricsBindingSubPageOpen"
-    module-label="Turbo"
-    :binding="config.modules.turbo.metricsBinding"
-    label="Metrics Capture Binding"
-    description="Start and stop frame-pacing metric collection while in-game. Arm it once you are actually flying and pause it before loading screens or menus, so the recorded numbers reflect real play."
-    none-text="No binding assigned. In keybinding mode, no metrics are recorded until a binding is set."
-    default-activate-sound="metrics-on.wav"
-    default-deactivate-sound="metrics-off.wav"
-    @update:binding="config.modules.turbo.metricsBinding = $event"
-    @close="metricsBindingSubPageOpen = false"
+  <TurboRuntimePage
+    v-else-if="activeSubPage === 'runtime'"
+    :config="config"
+    :runtime-pacing="runtimePacing"
+    :active-runtime="activeRuntime"
+    @rediscover-runtime="emit('rediscoverRuntime', $event)"
+    @close="closeSubPage"
+  />
+  <TurboDiagnosticsPage
+    v-else-if="activeSubPage === 'diagnostics'"
+    :config="config"
+    :turbo-metrics="turboMetrics"
+    @clear-turbo-metrics="emit('clearTurboMetrics')"
+    @close="closeSubPage"
   />
   <div v-else class="space-y-4">
-    <!-- Turbo module: frame pacing first (it decides how Turbo behaves),
-         then the toggle binding, then the default profile. -->
     <article class="rounded-[1.25rem] border p-5 shadow-panel backdrop-blur surface-panel">
-      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div class="mb-4 flex flex-wrap items-start justify-between gap-4">
         <div>
           <h2 class="text-2xl font-semibold tracking-tight">Turbo</h2>
           <p class="mt-2 max-w-3xl text-sm leading-6 text-muted">
-            Frees your game from the headset runtime's frame pacing so the GPU sets the pace. On some systems the runtime throttles frames at an unfortunate moment, capping fps well below what the hardware can deliver — Turbo removes that wait. If your fps is already stable, Turbo changes nothing worth having; it is a targeted fix, not a general boost.
+            Removes an unnecessary runtime wait when it is holding a game back. Choose where Turbo applies here; VectorXR handles the pacing details automatically.
           </p>
         </div>
         <button
@@ -326,9 +157,7 @@ function formatDeltaPercent(value: number): string {
           type="button"
           @click="howItWorksOpen = true"
         >
-          <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs" style="border-color: var(--app-border)">
-            i
-          </span>
+          <span class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs" style="border-color: var(--app-border)">i</span>
           How Turbo Works
         </button>
       </div>
@@ -338,295 +167,98 @@ function formatDeltaPercent(value: number): string {
         class="mb-5 rounded-[0.9rem] border px-4 py-3 text-sm leading-6 chip-warning"
         style="border-color: var(--app-border)"
       >
-        OpenXR Toolkit is enabled alongside VectorXR Turbo. Two frame-pacing layers fight each other — if OXRTK's own Turbo Mode is switched on, disable it there or here, never both.
+        OpenXR Toolkit is enabled alongside VectorXR Turbo. If OXRTK's Turbo Mode is also on, disable one of them so the two pacing layers do not compete.
       </div>
 
-      <!-- Frame pacing strategy -->
-      <div class="border-t pt-4" style="border-color: var(--app-border)">
+      <section class="border-t pt-4" style="border-color: var(--app-border)">
         <div class="mb-3">
-          <span class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Frame Pacing</span>
-          <p class="mt-1 max-w-3xl text-sm leading-6 text-muted">
-            How Turbo sequences the runtime's frame wait. Auto picks the right strategy per runtime and remembers what works — leave it on Auto unless you are debugging.
-          </p>
+          <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Essentials</p>
+          <p class="mt-1 text-sm text-muted">Turn Turbo on broadly, or leave the default off and enable only the applications that benefit.</p>
         </div>
 
-        <label class="flex flex-wrap items-center gap-3 text-sm font-medium">
-        Pacing mode
-        <select
-          v-model="config.modules.turbo.pacingMode"
-          class="rounded-[0.6rem] border px-3 py-1.5 text-sm surface-panel-strong"
-          style="border-color: var(--app-border)"
-        >
-          <option value="auto">Auto (recommended)</option>
-          <option value="async">Async — always</option>
-          <option value="sequenced">Sequenced — always</option>
-        </select>
-      </label>
-      <p class="mt-2 text-xs leading-5 text-muted">
-        <template v-if="!pacingForced">
-          Async overlaps the runtime wait with the next frame's work; Sequenced performs it right after each submit for runtimes that interlock the wait with submission (Oculus, Varjo, Pimax). Auto probes async first and falls back automatically.
-        </template>
-        <template v-else>
-          Forced mode: this strategy is used on every runtime. Per-runtime discovery and pins below are paused, and Turbo suspends itself (instead of adapting) if the runtime cannot keep pace.
-        </template>
-      </p>
-
-      <div class="mt-4 border-t pt-4" style="border-color: var(--app-border)">
-        <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
-          <span class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Runtimes</span>
-          <span v-if="activeRuntimeLabel" class="text-xs text-muted">
-            Active runtime: <span class="font-medium">{{ activeRuntimeLabel }}</span>
-          </span>
+        <div class="rounded-[1rem] border p-4 surface-panel-soft">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="max-w-2xl">
+              <h3 class="text-base font-semibold tracking-tight">Default Profile</h3>
+              <p class="mt-1 text-sm leading-6 text-muted">
+                {{ config.modules.turbo.enabled
+                  ? 'Turbo applies to applications without a custom profile.'
+                  : 'Turbo stays off unless an enabled custom profile turns it on.' }}
+              </p>
+            </div>
+            <label class="pill-toggle inline-flex items-center gap-3 rounded-full px-4 py-2 text-sm font-medium">
+              <input v-model="config.modules.turbo.enabled" class="h-4 w-4 accent-depthxr-copper" type="checkbox" />
+              Default {{ config.modules.turbo.enabled ? 'On' : 'Off' }}
+            </label>
+          </div>
         </div>
 
-        <div v-if="pacingRows.length === 0" class="rounded-[0.9rem] border border-dashed px-4 py-4 text-sm text-muted surface-panel-soft">
-          No runtimes observed yet — discoveries appear after Turbo's first session on each runtime.
-        </div>
-
-        <div v-else class="overflow-x-auto" :class="pacingForced ? 'opacity-50 pointer-events-none' : ''">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="text-left text-xs uppercase tracking-wide text-muted">
-                <th class="py-2 pr-3 font-medium">Runtime</th>
-                <th class="py-2 pr-3 font-medium">Mode</th>
-                <th class="py-2 pr-3 font-medium">Source</th>
-                <th class="py-2 pr-3 font-medium">Last used</th>
-                <th class="py-2 pr-3 font-medium">Override</th>
-                <th class="py-2 font-medium"></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="row in pacingRows"
-                :key="`${row.runtimeName}|${row.systemName}|${row.vendorId}|${row.graphicsApi}`"
-                class="border-t"
-                style="border-color: var(--app-border)"
-              >
-                <td class="py-2.5 pr-3">
-                  <span :class="row.isActive ? 'font-semibold' : ''">{{ row.runtimeName }}</span>
-                  <span v-if="row.runtimeVersion" class="ml-1 text-xs text-muted">{{ row.runtimeVersion }}</span>
-                  <span v-if="row.systemName || row.graphicsApi" class="mt-0.5 block text-xs text-muted">
-                    {{ row.systemName || 'Unknown headset' }}<template v-if="row.graphicsApi"> · {{ row.graphicsApi }}</template>
-                  </span>
-                  <span
-                    v-if="row.isActive"
-                    class="ml-2 rounded-full border px-2 py-0.5 text-[0.65rem] uppercase tracking-wide"
-                    style="border-color: var(--app-border)"
-                  >Active</span>
-                </td>
-                <td class="py-2.5 pr-3">{{ rowModeLabel(row) }}</td>
-                <td class="py-2.5 pr-3">
-                  <span
-                    v-if="rowBadge(row)"
-                    class="rounded-full border px-2 py-0.5 text-xs"
-                    style="border-color: var(--app-border)"
-                  >{{ rowBadge(row) }}</span>
-                </td>
-                <td class="py-2.5 pr-3 text-muted">{{ formatDate(row.lastUsedUnixSeconds) }}</td>
-                <td class="py-2.5 pr-3">
-                  <select
-                    :value="pinValue(row.runtimeName)"
-                    class="rounded-[0.5rem] border px-2 py-1 text-xs surface-panel-strong"
-                    style="border-color: var(--app-border)"
-                    @change="setPin(row.runtimeName, ($event.target as HTMLSelectElement).value)"
-                  >
-                    <option value="auto">Auto</option>
-                    <option value="async">Pin Async</option>
-                    <option value="sequenced">Pin Sequenced</option>
-                  </select>
-                </td>
-                <td class="py-2.5 text-right">
-                  <button
-                    v-if="row.source"
-                    class="button-secondary rounded-[0.5rem] px-2.5 py-1 text-xs"
-                    type="button"
-                    title="Clear this runtime's recorded verdict so Auto probes it again at the next session"
-                    @click="emit('rediscoverRuntime', row.runtimeName)"
-                  >
-                    Re-discover
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p v-if="pacingForced && pacingRows.length > 0" class="mt-2 text-xs text-muted">
-          Forced mode in effect for all runtimes — pins and discovery are paused. Switch back to Auto to use them.
-        </p>
-        <p v-else-if="activeRuntimeLabel && !activeRuntimeHasRow && pacingRows.length > 0" class="mt-2 text-xs text-muted">
-          No verdict yet for {{ activeRuntimeLabel }} — Auto will discover it on the next Turbo session.
-        </p>
-        </div>
-      </div>
-
-      <!-- Module-level binding — applies regardless of which profile enabled turbo -->
-      <div class="mt-4 border-t pt-4" style="border-color: var(--app-border)">
         <ModuleBindingPanel
-          heading="Turbo Toggle Binding"
+          class="mt-3"
+          heading="In-game Turbo Toggle"
           :binding="config.modules.turbo.toggleBinding"
-          hint="Flip Turbo on and off while in-game to compare fps and frame feel directly. Turbo starts enabled whenever it applies to the running application."
-          @edit="bindingSubPageOpen = true"
+          hint="Flip Turbo on and off while in-game for a direct comparison."
+          @edit="openToggleBinding"
         />
-      </div>
+      </section>
 
-      <!-- Frame pacing metrics: measured effect of each pacing strategy -->
-      <div class="mt-4 border-t pt-4" style="border-color: var(--app-border)">
-        <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <span class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Metrics</span>
-            <p class="mt-1 max-w-3xl text-sm leading-6 text-muted">
-              Measures what Turbo actually does to your frame pacing: fps, frame times, and time spent blocked on runtime pacing, recorded separately for Turbo off, async, and sequenced. Flip the Turbo toggle mid-flight to collect both sides of the comparison.
-            </p>
-          </div>
+      <section class="mt-5 border-t pt-4" style="border-color: var(--app-border)">
+        <div class="mb-3">
+          <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Tune &amp; Verify</p>
+          <p class="mt-1 text-sm text-muted">These tools are here when you need them, without getting between you and the basic setup.</p>
         </div>
 
-        <label class="flex flex-wrap items-center gap-3 text-sm font-medium">
-          Collection
-          <select
-            v-model="config.modules.turbo.metricsMode"
-            class="rounded-[0.6rem] border px-3 py-1.5 text-sm surface-panel-strong"
-            style="border-color: var(--app-border)"
+        <div class="grid gap-3 md:grid-cols-2">
+          <button
+            class="group rounded-[1rem] border p-4 text-left transition surface-panel-soft hover:-translate-y-0.5 hover:shadow-panel"
+            type="button"
+            @click="openSubPage('runtime')"
           >
-            <option value="always">Always while in-game</option>
-            <option value="binding">Only while capture binding is armed</option>
-            <option value="off">Off</option>
-          </select>
-        </label>
-        <p class="mt-2 text-xs leading-5 text-muted">
-          <template v-if="config.modules.turbo.metricsMode === 'binding'">
-            Nothing is recorded until you press the capture binding in-game; press it again to pause. Use it to cut loading screens and menus out of the data.
-          </template>
-          <template v-else-if="config.modules.turbo.metricsMode === 'always'">
-            Records whenever Turbo applies to the running application. Frame hitches over one second are excluded automatically, but menus and loading screens still count — use the capture binding mode for clean A/B comparisons.
-          </template>
-          <template v-else>
-            No metrics are recorded.
-          </template>
-        </p>
+            <div class="flex items-start justify-between gap-3">
+              <span class="inline-flex h-10 w-10 items-center justify-center rounded-[0.8rem] border surface-panel-strong" style="border-color: var(--app-border)">
+                <svg aria-hidden="true" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M3 5.5A2.5 2.5 0 0 1 5.5 3h9A2.5 2.5 0 0 1 17 5.5v4a2.5 2.5 0 0 1-2.5 2.5h-9A2.5 2.5 0 0 1 3 9.5v-4Zm2.5-.5a.5.5 0 0 0-.5.5v4a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5v-4a.5.5 0 0 0-.5-.5h-9ZM6 15a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H7a1 1 0 0 1-1-1Z" />
+                </svg>
+              </span>
+              <span class="rounded-full border px-3 py-1 text-xs font-medium" style="border-color: var(--app-border)">{{ pacingModeLabel }}</span>
+            </div>
+            <h3 class="mt-4 text-base font-semibold tracking-tight">Runtime Behavior</h3>
+            <p class="mt-1 min-h-[3rem] text-sm leading-6 text-muted">{{ pacingSummary }}</p>
+            <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium">
+              Review pacing
+              <span aria-hidden="true" class="transition group-hover:translate-x-1">→</span>
+            </span>
+          </button>
 
-        <div v-if="config.modules.turbo.metricsMode === 'binding'" class="mt-3">
-          <ModuleBindingPanel
-            heading="Metrics Capture Binding"
-            :binding="config.modules.turbo.metricsBinding"
-            hint="Arm capture once you are actually flying; pause it before loading screens or menus."
-            @edit="metricsBindingSubPageOpen = true"
-          />
+          <button
+            class="group rounded-[1rem] border p-4 text-left transition surface-panel-soft hover:-translate-y-0.5 hover:shadow-panel"
+            type="button"
+            @click="openSubPage('diagnostics')"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <span class="inline-flex h-10 w-10 items-center justify-center rounded-[0.8rem] border surface-panel-strong" style="border-color: var(--app-border)">
+                <svg aria-hidden="true" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M3 15a1 1 0 0 1 1-1h1.5V9.5a1 1 0 0 1 2 0V14H9V5a1 1 0 0 1 2 0v9h1.5V7.5a1 1 0 0 1 2 0V14H16a1 1 0 1 1 0 2H4a1 1 0 0 1-1-1Z" />
+                </svg>
+              </span>
+              <span class="rounded-full border px-3 py-1 text-xs font-medium" style="border-color: var(--app-border)">{{ metricsModeLabel }}</span>
+            </div>
+            <h3 class="mt-4 text-base font-semibold tracking-tight">Performance Diagnostics</h3>
+            <p class="mt-1 min-h-[3rem] text-sm leading-6 text-muted">{{ metricsSummary }}</p>
+            <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium">
+              View performance checks
+              <span aria-hidden="true" class="transition group-hover:translate-x-1">→</span>
+            </span>
+          </button>
         </div>
-
-        <div class="mt-4">
-          <div v-if="turboMetrics.length === 0" class="rounded-[0.9rem] border border-dashed px-4 py-4 text-sm text-muted surface-panel-soft">
-            No metrics captured yet — they appear here after the first Turbo-enabled session (updated every ~15 seconds while playing).
-          </div>
-
-          <template v-else>
-            <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <label class="flex flex-wrap items-center gap-2 text-xs font-medium text-muted">
-                Session
-                <select
-                  :value="selectedSession?.sessionId ?? ''"
-                  class="rounded-[0.5rem] border px-2 py-1 text-xs surface-panel-strong"
-                  style="border-color: var(--app-border)"
-                  @change="selectedSessionId = ($event.target as HTMLSelectElement).value"
-                >
-                  <option v-for="session in turboMetrics" :key="session.sessionId" :value="session.sessionId">
-                    {{ formatSessionLabel(session) }}
-                  </option>
-                </select>
-              </label>
-              <button
-                class="button-secondary rounded-[0.5rem] px-2.5 py-1 text-xs"
-                type="button"
-                title="Delete all recorded metric sessions"
-                @click="emit('clearTurboMetrics')"
-              >
-                Clear metrics
-              </button>
-            </div>
-
-            <div
-              v-for="comparison in comparisons"
-              :key="comparison.label"
-              class="mb-2 rounded-[0.9rem] border px-4 py-3 text-sm leading-6 surface-panel-strong"
-            >
-              <span class="font-semibold">{{ formatDeltaPercent(comparison.deltaPercent) }} average fps</span>
-              with {{ comparison.label }} vs Turbo off ({{ comparison.offFps.toFixed(1) }} → {{ comparison.turboFps.toFixed(1) }} fps).
-              <span class="text-muted">Both states measured in this session; the comparison is only as fair as the scenes were similar.</span>
-            </div>
-
-            <div v-if="selectedBuckets.length === 0" class="rounded-[0.9rem] border border-dashed px-4 py-4 text-sm text-muted surface-panel-soft">
-              This session has no captured frames yet.
-            </div>
-            <div v-else class="overflow-x-auto">
-              <table class="w-full text-sm">
-                <thead>
-                  <tr class="text-left text-xs uppercase tracking-wide text-muted">
-                    <th class="py-2 pr-3 font-medium">Pacing</th>
-                    <th class="py-2 pr-3 font-medium">Time</th>
-                    <th class="py-2 pr-3 font-medium">Avg fps</th>
-                    <th class="py-2 pr-3 font-medium">1% low fps</th>
-                    <th class="py-2 pr-3 font-medium">Avg frame</th>
-                    <th class="py-2 pr-3 font-medium">p99 frame</th>
-                    <th class="py-2 pr-3 font-medium" title="Average per-frame time the game spent blocked on runtime pacing">Wait blocked</th>
-                    <th class="py-2 font-medium" title="Frame-pacing stalls counted by the safety circuit">Stalls</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    v-for="bucket in selectedBuckets"
-                    :key="bucket.state"
-                    class="border-t"
-                    style="border-color: var(--app-border)"
-                  >
-                    <td class="py-2.5 pr-3 font-medium">{{ bucketLabel(bucket.state) }}</td>
-                    <td class="py-2.5 pr-3 text-muted">{{ formatSeconds(bucket.seconds) }}</td>
-                    <td class="py-2.5 pr-3">{{ bucket.avgFps.toFixed(1) }}</td>
-                    <td class="py-2.5 pr-3">{{ onePercentLowFps(bucket) }}</td>
-                    <td class="py-2.5 pr-3">{{ bucket.avgFrameMs.toFixed(2) }} ms</td>
-                    <td class="py-2.5 pr-3">{{ bucket.p99FrameMs.toFixed(2) }} ms</td>
-                    <td class="py-2.5 pr-3">{{ bucket.avgWaitBlockMs.toFixed(2) }} ms</td>
-                    <td class="py-2.5">{{ bucket.drainTimeouts }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <p v-if="selectedSession" class="mt-2 text-xs text-muted">
-              {{ selectedSession.live ? 'Session in progress — updates every ~15s.' : 'Session complete.' }}
-              Collection mode: {{ selectedSession.collectionMode === 'binding' ? 'capture binding' : 'always' }}.
-              <template v-if="selectedBuckets.some((bucket) => bucket.discardedFrames > 0)">
-                Frame hitches over 1s are excluded from the stats.
-              </template>
-            </p>
-          </template>
-        </div>
-      </div>
-
-      <details class="section-disclosure mt-4 border-t pt-4" style="border-color: var(--app-border)" open>
-        <summary class="flex items-center gap-2">
-          <svg aria-hidden="true" class="section-chevron h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M7.2 14.8a1 1 0 0 1 0-1.4L10.6 10 7.2 6.6a1 1 0 1 1 1.4-1.4l4.1 4.1a1 1 0 0 1 0 1.4l-4.1 4.1a1 1 0 0 1-1.4 0Z" clip-rule="evenodd" />
-          </svg>
-          <span class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Default Profile</span>
-          <span class="text-xs text-muted">Applies to applications without an enabled custom profile</span>
-        </summary>
-
-        <label class="pill-toggle mt-3 inline-flex items-center gap-3 rounded-full px-4 py-2 text-sm font-medium">
-          <input v-model="config.modules.turbo.enabled" class="h-4 w-4 accent-depthxr-copper" type="checkbox" />
-          Default Profile {{ config.modules.turbo.enabled ? 'On' : 'Off' }}
-        </label>
-
-        <div v-if="!config.modules.turbo.enabled" class="mt-3 rounded-[0.9rem] border px-4 py-3 text-sm leading-6 surface-panel-strong">
-          The default profile is off — Turbo does not apply to applications without an enabled custom profile. Enabled custom profiles below still turn Turbo on for their assigned applications.
-        </div>
-      </details>
+      </section>
     </article>
 
-    <!-- Custom Profiles -->
     <section class="space-y-3">
-      <div class="flex flex-wrap items-center justify-between gap-3 rounded-[1rem] border px-4 py-3 surface-panel">
+      <div class="sticky top-0 z-20 flex flex-wrap items-center justify-between gap-3 rounded-[1rem] border px-4 py-3 shadow-panel backdrop-blur surface-panel-strong">
         <div>
           <h2 class="text-lg font-semibold tracking-tight">Custom Profiles</h2>
-          <p class="text-sm text-muted">Enable Turbo for specific applications while leaving the default off.</p>
+          <p class="text-sm text-muted">Enable Turbo for selected applications while leaving the default off.</p>
         </div>
         <button
           class="button-accent rounded-[0.75rem] px-5 py-2.5 text-sm font-medium"
@@ -635,6 +267,10 @@ function formatDeltaPercent(value: number): string {
         >
           Add Profile
         </button>
+      </div>
+
+      <div v-if="config.modules.turbo.enabled" class="rounded-[0.9rem] border px-4 py-3 text-sm leading-6 surface-panel-soft">
+        The default is already on, so Turbo applies without a custom profile. Turn the default off if you want to use this list as an application allowlist.
       </div>
 
       <ProfileShell
@@ -648,7 +284,7 @@ function formatDeltaPercent(value: number): string {
         @sync-name="$emit('syncTurboProfileName', index)"
       >
         <div class="rounded-[0.9rem] border px-4 py-3 text-sm leading-6 surface-panel-strong">
-          Turbo is on for this profile's applications. There is nothing further to tune — pacing is either overridden or it isn't.
+          Turbo is on for this profile's applications. Runtime behavior remains automatic unless you changed it on the Runtime Behavior page.
         </div>
       </ProfileShell>
 
@@ -656,7 +292,7 @@ function formatDeltaPercent(value: number): string {
         v-if="config.modules.turbo.profiles.length === 0"
         class="rounded-[1rem] border border-dashed px-6 py-7 text-center text-sm surface-panel-soft"
       >
-        No custom profiles yet. Add a profile to enable Turbo for a specific application.
+        No custom profiles yet. Add one when an application needs different behavior from the default.
       </div>
     </section>
 
@@ -667,36 +303,34 @@ function formatDeltaPercent(value: number): string {
             <p class="eyebrow text-xs uppercase tracking-[0.24em]">Turbo Mode</p>
             <h2 class="mt-2 text-xl font-semibold tracking-tight">How Turbo Works</h2>
           </div>
-          <button class="button-secondary rounded-[0.75rem] px-4 py-2 text-sm font-medium" type="button" @click="howItWorksOpen = false">
-            Close
-          </button>
+          <button class="button-secondary rounded-[0.75rem] px-4 py-2 text-sm font-medium" type="button" @click="howItWorksOpen = false">Close</button>
         </div>
 
         <div class="mt-5 space-y-5 text-sm leading-6">
           <section class="space-y-3">
             <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">What it does</p>
             <div class="rounded-[1rem] border px-4 py-3 surface-panel">
-              A game normally idles until the headset runtime signals the next frame. Turbo performs that wait out of the game's way, so it starts its next frame the moment the previous one is submitted. The runtime still receives a fully correct frame sequence.
+              A game normally idles until the headset runtime signals the next frame. Turbo performs that wait out of the game's way, so the game can begin its next frame as soon as the previous one is submitted. The runtime still receives a correct frame sequence.
             </div>
             <div class="rounded-[1rem] border px-4 py-3 surface-panel">
-              <strong>Auto</strong> (recommended) picks the wait strategy per runtime and remembers what works: <strong>Async</strong> waits in the background where supported (SteamVR); <strong>Sequenced</strong> waits right after each submit where required (Pimax, Oculus, Varjo).
+              <strong>Auto</strong> chooses the wait strategy and remembers what works: <strong>Async</strong> waits in the background where supported, while <strong>Sequenced</strong> supports runtimes that interlock waiting with submission.
             </div>
           </section>
 
           <section class="space-y-3">
             <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">What to expect</p>
             <div class="rounded-[1rem] border px-4 py-3 surface-panel">
-              Turbo is a targeted fix, not a general boost: it helps only when the runtime caps fps below what your hardware can deliver. It cannot raise a runtime-enforced framerate lock (such as half-rate smoothing) on Sequenced runtimes. Use the Metrics section with the toggle binding to measure what it changes for you — if a title shows no benefit, leave Turbo off there.
+              Turbo is a targeted fix, not a general boost. It helps only when runtime pacing holds fps below what the hardware can deliver, and it cannot remove a runtime-enforced framerate lock. Use Performance Diagnostics with the in-game toggle to measure each title.
             </div>
             <div class="rounded-[1rem] border px-4 py-3 chip-warning" style="border-color: var(--app-border)">
-              Trade-offs: slightly less accurate frame-time prediction (can read as minor latency or judder), and toggling mid-session may hitch for a second.
+              Trade-offs: frame-time prediction may be slightly less accurate, and switching Turbo on mid-session can briefly hitch while the frame pipeline re-synchronizes.
             </div>
           </section>
 
           <section class="space-y-3">
             <p class="eyebrow text-xs font-semibold uppercase tracking-[0.24em]">Safety net</p>
             <div class="rounded-[1rem] border px-4 py-3 chip-warning" style="border-color: var(--app-border)">
-              If frame pacing stalls even after Auto adapts, Turbo suspends itself for the session (you'll hear the turbo-off cue) and records the runtime as unsupported so the stutter never replays at launch. Press the toggle binding to retry — a clean run clears the verdict.
+              If pacing stalls even after Auto adapts, Turbo suspends itself for that session and remembers the runtime as unsupported so the stutter does not replay at launch. Use the in-game toggle to retry; a clean run clears the verdict.
             </div>
           </section>
         </div>

--- a/app/src/lib/model.ts
+++ b/app/src/lib/model.ts
@@ -224,6 +224,9 @@ export interface TurboModuleConfig {
 export interface RuntimePacingObservation {
   runtimeName: string
   runtimeVersion: string
+  systemName: string
+  vendorId: number
+  graphicsApi: string
   mode: TurboPacingMode | 'unsupported'
   source: 'preset' | 'discovered'
   layerVersion: string

--- a/app/src/lib/patchNotes.ts
+++ b/app/src/lib/patchNotes.ts
@@ -8,6 +8,18 @@ export interface PatchNoteEntry {
 
 export const patchNotes: PatchNoteEntry[] = [
   {
+    version: '0.13.0',
+    date: '2026-07-10',
+    title: 'Performance & Runtime Hardening',
+    summary: 'Refines Turbo and the core OpenXR architecture for smoother performance, broader runtime compatibility, and a clearer configuration experience.',
+    items: [
+      'Refactored Turbo frame pacing to reduce overhead, improve lifecycle stability, and avoid unnecessary performance penalties in titles that do not benefit from it.',
+      'Reorganized Turbo into focused Runtime Behavior and Performance Diagnostics pages that keep everyday setup simple while preserving advanced controls.',
+      'Improved Quadviews compatibility and rendering resilience, including stronger native Varjo behavior and new opinionated performance presets.',
+      'Strengthened session, swapchain, graphics-state, tracking, and logging architecture throughout the OpenXR layer.',
+    ],
+  },
+  {
     version: '0.12.3',
     date: '2026-07-08',
     title: 'Pivot Pitch Fix',

--- a/docs/runtime-hardening.md
+++ b/docs/runtime-hardening.md
@@ -1,0 +1,47 @@
+# Runtime Hardening Notes
+
+This document records the compatibility boundaries introduced on `sol-review`.
+The goal is to preserve VectorXR's existing Quadviews, Pivot, and Turbo behavior
+while making unsupported paths explicit and frame ownership deterministic.
+
+## Quadviews backends
+
+- Native Varjo extensions are forwarded whenever the active runtime supports
+  them, independently of whether a VectorXR Quadviews profile is enabled.
+- VectorXR settings modify native Varjo view sizes and sharpening only when the
+  resolved profile is enabled. Disabled profiles are transparent.
+- Synthesized quadviews is exposed only to D3D11 OpenXR applications. Other
+  graphics APIs pass through without advertising an emulation backend that
+  cannot composite reliably.
+- The D3D11 compositor preserves complete application context state on D3D11.1
+  devices and retains the previous manual state path as a compatibility fallback.
+- Swapchain acquisition/wait/release tracking follows FIFO ordering. Array
+  swapchains are flattened one selected slice at a time through the existing
+  copy fallback, and submitted subimage rectangles are respected by the shader.
+
+## Turbo lifecycle
+
+- Async pacing uses one persistent worker. The one-frame overlap and the
+  existing Async/Sequenced behavior are unchanged.
+- `xrEndSession` is intercepted. Any frame pre-owned by Turbo is balanced before
+  the downstream session end, and frame/tracking state is reset before restart.
+- Runtime pacing observations are keyed by runtime, headset system/vendor, and
+  graphics API. This prevents a SteamVR verdict learned through one headset
+  driver from being applied blindly to another.
+
+## Pivot and gaze
+
+- Pivot normally derives eye offsets from the runtime views already located for
+  the frame. The extra runtime `xrLocateViews` remains as a validity fallback.
+- Eye-gaze focus holds the last valid sample across short dropouts and then eases
+  back to center instead of snapping on a blink.
+
+## Deliberate remaining boundaries
+
+- D3D12 and Vulkan synthesized-quadviews backends are not yet implemented.
+- VectorXR still owns one instance/session state object. Additional instances or
+  sessions are rejected safely instead of overwriting the active dispatch state;
+  a full handle-to-instance dispatch map is future architectural work.
+- A deterministic mock OpenXR runtime should be added for end-to-end frame-loop
+  ordering tests. Pure swapchain FIFO behavior is covered in the current native
+  test executable.

--- a/docs/turbo-pacing.md
+++ b/docs/turbo-pacing.md
@@ -1,6 +1,6 @@
 # Turbo Frame Pacing: Auto Discovery Design
 
-Status: implemented (first draft) on `feature-branch-twelve`, July 2026.
+Status: implemented and hardened on `sol-review`, July 2026.
 
 ## Problem
 
@@ -21,7 +21,9 @@ Diagnostic signature in debug logs: `turboDrainAndBegin max` pinned at ~250 ms,
 
 - **Async** — background-thread wait, drained at the next EndFrame. Best
   overlap (the pacing wait runs concurrently with the app's next-frame CPU
-  work). Fails on interlocking runtimes.
+  work). Fails on interlocking runtimes. VectorXR now uses one persistent
+  per-instance worker instead of launching a new `std::async` task every frame;
+  overlap is unchanged while thread identity and scheduling are stable.
 - **Sequenced** — the real wait+begin run *synchronously on the app's frame
   thread* inside EndFrame, right after the submit. From the runtime's view
   this is the standard single-threaded frame loop (End → Wait → Begin), which
@@ -130,10 +132,11 @@ straight to suspend, preserving pre-0.13 behavior.
 1. `turbo.pacingMode` forced to async/sequenced in settings → use it, no
    discovery, no sidecar writes.
 2. `turbo.runtimePins[runtimeName]` (Auto only) → pinned mode.
-3. Recorded verdict in `runtime-pacing.json` → use it (refreshes `lastUsed`).
+3. Recorded verdict for the runtime + headset + graphics fingerprint in
+   `runtime-pacing.json` → use it (refreshes `lastUsed`).
 4. Seed table: Oculus / Varjo / PiOpenXR / Pimax → sequenced; SteamVR → async.
    Recorded as a `preset` verdict after a stable window.
-5. Unknown runtime → probe async with the hair trigger; fall back to
+5. Unknown fingerprint → probe async with the hair trigger; fall back to
    sequenced on stalls. Recorded as `discovered` after a stable window.
 
 A **stable window** is 60 s of engaged turbo with zero drain timeouts. Config
@@ -145,7 +148,8 @@ changes to `pacingMode`/`runtimePins` re-resolve mid-session.
   (`auto|async|sequenced`, default `auto`) and `turbo.runtimePins`
   (`{ runtimeName: async|sequenced }`).
 - `runtime-pacing.json` sidecar (facts, layer-written, seen-apps pattern):
-  one observation per runtime — name, version, mode
+  one observation per runtime/headset/graphics fingerprint — runtime name and
+  version, system name/vendor, graphics API, mode
   (`async|sequenced|unsupported`), source (`preset|discovered`), layer
   version, first/last used, probe stats. Ships in debug reports. The app's
   "Re-discover" removes one runtime's row; the layer re-probes next session.

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
     src/settings.cpp
     src/sound_player.cpp
     src/settings_resolver.cpp
+    src/swapchain_state.cpp
     src/util/config_path.cpp
     src/util/logger.cpp
     src/util/process_info.cpp

--- a/layer/include/depthxr/logger.h
+++ b/layer/include/depthxr/logger.h
@@ -36,6 +36,7 @@ class Logger {
     std::filesystem::path base_log_path_;
     std::filesystem::path active_log_path_;
     std::ofstream stream_;
+    std::chrono::steady_clock::time_point last_stream_flush_time_{};
     LogLevel level_{LogLevel::Info};
     int retention_files_{7};
     LogLevel pending_duplicate_level_{LogLevel::Info};

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <future>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <span>
@@ -22,12 +23,16 @@
 #include "depthxr/config_parser.h"
 #include "depthxr/effects.h"
 #include "depthxr/logger.h"
+#include "depthxr/runtime_pacing.h"
 #include "depthxr/settings_resolver.h"
+#include "depthxr/swapchain_state.h"
 
 struct ID3D11BlendState;
 struct ID3D11Buffer;
 struct ID3D11Device;
 struct ID3D11DeviceContext;
+struct ID3D11DeviceContext1;
+struct ID3DDeviceContextState;
 struct ID3D11PixelShader;
 struct ID3D11Query;
 struct ID3D11RenderTargetView;
@@ -44,6 +49,7 @@ class OpenXrLayer {
 
     void SetLayerDirectory(std::filesystem::path dll_directory);
     void SetNextProcAddr(PFN_xrGetInstanceProcAddr next_get_instance_proc_addr);
+    bool CanCreateInstance();
 
     struct InstanceCreateDiagnostics {
         bool app_requested_quad_views{false};
@@ -61,11 +67,10 @@ class OpenXrLayer {
         // the runtime (Varjo compatible quadviews) instead of stripping them for
         // stereo-composite emulation.
         bool varjo_compatible_quad_forwarded{false};
-        // Diagnostics for WHY Varjo compatible forwarding did/did not happen. The
-        // forward requires eligible && the runtime advertising XR_VARJO_quad_views
-        // to a pre-instance extension probe. These capture each input plus the raw
-        // extension list the probe saw, so a truncation-free (short-session) capture
-        // pinpoints the cause.
+        // Diagnostics for native forwarding and for whether VectorXR's own
+        // profile is eligible to modify that native path. Forwarding itself is
+        // transparent whenever the active runtime is Varjo or advertises every
+        // requested native extension.
         bool varjo_compatible_eligible{false};
         bool runtime_advertises_varjo_quad{false};
         bool runtime_advertises_varjo_foveated{false};
@@ -73,8 +78,8 @@ class OpenXrLayer {
         XrResult pre_instance_extension_scan_result{XR_SUCCESS};
         uint32_t pre_instance_extension_count{0};
         std::string pre_instance_extensions;
-        // Authoritative Varjo signal: the active OpenXR runtime (from the registry).
-        // This, not the extension probe, now drives the forward decision.
+        // Authoritative fallback Varjo signal: the active runtime manifest.
+        // This covers Varjo's unreliable pre-instance extension enumeration.
         bool active_runtime_is_varjo{false};
         std::string active_runtime_path;
     };
@@ -94,6 +99,7 @@ class OpenXrLayer {
     XrResult CreateSession(XrInstance instance, const XrSessionCreateInfo* create_info, XrSession* session);
     XrResult DestroySession(XrSession session);
     XrResult BeginSession(XrSession session, const XrSessionBeginInfo* begin_info);
+    XrResult EndSession(XrSession session);
     XrResult AttachSessionActionSets(XrSession session, const XrSessionActionSetsAttachInfo* attach_info);
     XrResult SyncActions(XrSession session, const XrActionsSyncInfo* sync_info);
     XrResult WaitFrame(XrSession session, const XrFrameWaitInfo* frame_wait_info, XrFrameState* frame_state);
@@ -181,10 +187,11 @@ class OpenXrLayer {
         bool images_enumerated{false};
         bool has_last_acquired_image_index{false};
         bool has_last_released_image_index{false};
-        bool release_deferred{false};
+        uint32_t deferred_release_count{0};
         bool quadviews_session{false};
-        bool d3d11_shader_resources_attempted{false};
-        bool d3d11_shader_resources_available{false};
+        SwapchainImageQueue image_states;
+        std::unordered_set<uint32_t> d3d11_shader_resource_slices_attempted;
+        std::unordered_set<uint32_t> d3d11_shader_resource_slices_available;
         std::vector<ID3D11Texture2D*> d3d11_images;
         std::vector<ID3D11ShaderResourceView*> d3d11_shader_resources;
     };
@@ -220,6 +227,8 @@ class OpenXrLayer {
     struct D3D11QuadViewsCompositor {
         ID3D11Device* device{nullptr};
         ID3D11DeviceContext* context{nullptr};
+        ID3D11DeviceContext1* context1{nullptr};
+        ID3DDeviceContextState* layer_context_state{nullptr};
         ID3D11VertexShader* vertex_shader{nullptr};
         ID3D11PixelShader* pixel_shader{nullptr};
         ID3D11SamplerState* sampler{nullptr};
@@ -314,6 +323,8 @@ class OpenXrLayer {
     // frame thread after the lock is released.
     void ResolveTurboPacingModeLocked();
     void RecordTurboPacingVerdict(TurboPacingMode mode, const char* source, std::int64_t stable_seconds);
+    void QueueRuntimePacingWrite(RuntimePacingObservation observation);
+    void DrainRuntimePacingWrites();
     void NoteTurboPacingStableFrame(double app_frame_delta_ms);
     // Returns true when turbo should suspend for the session (level-2 trip or
     // non-auto mode); false when it adapted (async -> sequenced fallback).
@@ -324,6 +335,9 @@ class OpenXrLayer {
     XrResult ForwardEndFrame(XrSession session,
                              const XrFrameEndInfo* frame_end_info,
                              std::unique_lock<std::mutex>& config_lock);
+    void EnsureTurboAsyncWorkerLocked();
+    void StopTurboAsyncWorker();
+    void TurboAsyncWorkerLoop();
     void DrainTurboAsyncWait();
     void ResetTurboFrameState();
     // Frame pacing telemetry: logs a summary line (debug level) every ~5s so a
@@ -355,6 +369,7 @@ class OpenXrLayer {
     // frame loop keeps running — worth an info line the first few times.
     void NoteTurboShouldRenderLocked(bool should_render);
     bool IsQuadViewsActive() const;
+    bool IsQuadViewsEmulationActive() const;
     void ResetSwapchainState();
     void LogSwapchainSummary(XrSwapchain swapchain, const SwapchainInfo& info, std::string_view event_name);
     bool ShouldDeferSwapchainRelease(const SwapchainInfo& info) const;
@@ -381,6 +396,11 @@ class OpenXrLayer {
                           XrViewConfigurationType view_configuration_type,
                           XrTime display_time,
                           uint32_t view_count);
+    bool CacheEyeOffsetsFromLocatedViews(XrViewConfigurationType view_configuration_type,
+                                         XrTime display_time,
+                                         const XrPosef& runtime_view_pose,
+                                         std::span<const XrView> located_views,
+                                         uint32_t view_count);
     void CachePivotPoseDelta(XrTime time, const XrPosef& pose_delta);
     bool FindPivotPoseDelta(XrTime time, XrPosef* pose_delta, XrTime* matched_time) const;
     void PrunePivotPoseDeltas(XrTime time);
@@ -415,7 +435,7 @@ class OpenXrLayer {
                                         uint32_t output_width,
                                         uint32_t output_height,
                                         int64_t output_format);
-    bool EnsureD3D11SwapchainShaderResources(SwapchainInfo& swapchain);
+    bool EnsureD3D11SwapchainShaderResources(SwapchainInfo& swapchain, uint32_t array_slice = 0);
     void TryPrewarmD3D11QuadViewsCompositor();
     bool ComposeQuadViewsD3D11(const XrCompositionLayerProjection* source_layer,
                                XrTime display_time,
@@ -461,6 +481,9 @@ class OpenXrLayer {
     std::condition_variable config_watcher_cv_;
     bool config_watcher_stop_{false};
     std::string runtime_name_;
+    std::string system_name_;
+    uint32_t system_vendor_id_{0};
+    std::string graphics_api_;
     std::string current_exe_name_;
     ResolvedRuntimeConfig resolved_settings_;
     std::optional<ResolvedRuntimeConfig> last_logged_settings_;
@@ -534,12 +557,23 @@ class OpenXrLayer {
     // spec-ordering requires it (second poll, teardown drains). mutex_ must
     // NOT be required by WaitFrame/BeginFrame, which stay off the config lock.
     std::mutex turbo_mutex_;
-    std::future<void> turbo_async_wait_;
+    std::condition_variable turbo_async_worker_cv_;
+    std::thread turbo_async_worker_;
+    bool turbo_async_worker_stop_{false};
+    bool turbo_async_job_pending_{false};
+    XrSession turbo_async_job_session_{XR_NULL_HANDLE};
+    std::shared_ptr<std::promise<void>> turbo_async_job_completion_;
+    // Shared snapshots let WaitFrame, EndFrame, and teardown observe the same
+    // in-flight wait without concurrently mutating a std::future object.
+    std::shared_future<void> turbo_async_wait_;
+    std::uint64_t turbo_async_wait_generation_{0};
     bool turbo_async_wait_polled_{false};
     bool turbo_async_wait_completed_{false};
+    XrResult turbo_async_wait_result_{XR_SUCCESS};
     XrTime turbo_last_predicted_display_time_{0};
     XrDuration turbo_last_predicted_display_period_{0};
     bool turbo_last_should_render_{true};
+    XrEnvironmentBlendMode turbo_last_environment_blend_mode_{XR_ENVIRONMENT_BLEND_MODE_OPAQUE};
     XrTime turbo_max_returned_display_time_{0};
     std::optional<std::chrono::steady_clock::time_point> turbo_last_wait_frame_wall_time_;
     // Toggle binding state (mutex_-guarded, polled from EndFrame like Depth's).
@@ -577,6 +611,8 @@ class OpenXrLayer {
     // Auto only: a stable window is still owed before the verdict is written.
     bool turbo_pacing_verdict_pending_{false};
     std::int64_t turbo_probe_timeout_total_{0};
+    std::future<void> runtime_pacing_write_future_;
+    std::optional<RuntimePacingObservation> pending_runtime_pacing_write_;
     // Accumulated healthy engaged frame time; the verdict lands at 60s. Not
     // wall-clock, so loading screens neither earn nor destroy stability.
     double turbo_stable_accumulated_ms_{0.0};
@@ -743,6 +779,7 @@ class OpenXrLayer {
     std::optional<bool> app_submitting_layers_;
     bool quad_views_extension_requested_{false};
     bool varjo_foveated_rendering_extension_requested_{false};
+    bool d3d11_graphics_extension_requested_{false};
     bool eye_gaze_extension_enabled_{false};
     // True for the life of the instance when native Varjo quad-views were
     // forwarded to the runtime (Varjo compatible quadviews). Single source of truth
@@ -767,6 +804,7 @@ class OpenXrLayer {
     double quadviews_smoothed_focus_yaw_radians_{0.0};
     double quadviews_smoothed_focus_pitch_radians_{0.0};
     std::optional<std::chrono::steady_clock::time_point> quadviews_last_focus_smoothing_wall_time_;
+    std::optional<std::chrono::steady_clock::time_point> quadviews_last_valid_gaze_wall_time_;
     XrViewConfigurationType active_primary_view_configuration_type_{XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO};
     XrViewConfigurationType active_runtime_view_configuration_type_{XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO};
     bool has_active_primary_view_configuration_{false};
@@ -786,6 +824,7 @@ class OpenXrLayer {
     XrTime cached_eye_offsets_display_time_{0};
     XrViewConfigurationType cached_eye_offsets_view_configuration_{XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO};
     std::optional<std::chrono::steady_clock::time_point> last_app_action_sync_time_;
+    std::optional<std::chrono::steady_clock::time_point> last_eye_gaze_self_sync_time_;
     std::vector<ViewAdjustmentData> locate_views_original_scratch_;
     std::vector<ViewAdjustmentData> locate_views_adjusted_scratch_;
     std::vector<std::vector<XrCompositionLayerProjectionView>> end_frame_projection_views_scratch_;
@@ -803,6 +842,7 @@ class OpenXrLayer {
     PFN_xrCreateSession next_create_session_{nullptr};
     PFN_xrDestroySession next_destroy_session_{nullptr};
     PFN_xrBeginSession next_begin_session_{nullptr};
+    PFN_xrEndSession next_end_session_{nullptr};
     PFN_xrAttachSessionActionSets next_attach_session_action_sets_{nullptr};
     PFN_xrSyncActions next_sync_actions_{nullptr};
     PFN_xrWaitFrame next_wait_frame_{nullptr};

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -252,6 +252,8 @@ class OpenXrLayer {
         bool initialized{false};
         bool failed{false};
         bool has_logged_active{false};
+        bool has_logged_skipped{false};
+        uint32_t consecutive_skipped_frames{0};
         uint32_t failure_logs_remaining{8};
         std::array<QuadViewsCompositionTarget, 2> targets;
     };

--- a/layer/include/depthxr/runtime_pacing.h
+++ b/layer/include/depthxr/runtime_pacing.h
@@ -10,13 +10,16 @@
 
 namespace depthxr {
 
-// One pacing verdict per OpenXR runtime, persisted to runtime-pacing.json
+// One pacing verdict per runtime/headset/graphics fingerprint, persisted to runtime-pacing.json
 // (seen-apps pattern: layer-written facts, app-read, ships in debug reports).
 // Settings carry user intent (pacing mode, pins); this file carries what Auto
 // actually learned, so the two never race over settings.json.
 struct RuntimePacingObservation {
     std::string runtime_name;
     std::string runtime_version;
+    std::string system_name;
+    std::uint32_t vendor_id{0};
+    std::string graphics_api;
     TurboPacingMode mode{TurboPacingMode::kAsync};
     // "preset" (seed table, never probed) or "discovered" (probed and
     // confirmed stable, or the fallback verdict after a probe failure).
@@ -35,9 +38,12 @@ std::filesystem::path ResolveRuntimePacingPath();
 std::vector<RuntimePacingObservation> ReadRuntimePacingObservations(const std::filesystem::path& path);
 
 std::optional<RuntimePacingObservation> FindRuntimePacingObservation(const std::filesystem::path& path,
-                                                                     const std::string& runtime_name);
+                                                                     const std::string& runtime_name,
+                                                                     const std::string& system_name = {},
+                                                                     std::uint32_t vendor_id = 0,
+                                                                     const std::string& graphics_api = {});
 
-// Upserts by runtime_name, preserving first_used and merging probe stats.
+// Upserts by runtime/system/graphics fingerprint, preserving first_used.
 bool RecordRuntimePacingObservation(const std::filesystem::path& path,
                                     const RuntimePacingObservation& observation,
                                     std::string* error);

--- a/layer/include/depthxr/swapchain_state.h
+++ b/layer/include/depthxr/swapchain_state.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <optional>
+
+namespace depthxr {
+
+// Mirrors OpenXR's implicit FIFO operations: wait targets the oldest acquired
+// image that has not been waited, and release targets the oldest waited image.
+// The downstream release can lag the app release while VectorXR composites.
+class SwapchainImageQueue {
+  public:
+    void Acquire(uint32_t image_index);
+    std::optional<uint32_t> WaitOldest();
+    std::optional<uint32_t> ReleaseOldest();
+    std::optional<uint32_t> ReleaseDownstreamOldest();
+    void Clear();
+
+    [[nodiscard]] size_t Size() const;
+    [[nodiscard]] size_t PendingDownstreamReleases() const;
+
+  private:
+    struct ImageState {
+        uint32_t index{0};
+        bool waited{false};
+        bool app_released{false};
+        bool downstream_released{false};
+    };
+
+    void RetireReleasedPrefix();
+
+    std::deque<ImageState> states_;
+};
+
+} // namespace depthxr

--- a/layer/manifest/XR_APILAYER_DIENERTECH_VECTORXR.json
+++ b/layer/manifest/XR_APILAYER_DIENERTECH_VECTORXR.json
@@ -3,7 +3,7 @@
   "api_layer": {
     "name": "XR_APILAYER_DIENERTECH_VECTORXR",
     "library_path": ".\\XR_APILAYER_DIENERTECH_VECTORXR.dll",
-    "api_version": "1.0",
+    "api_version": "1.1",
     "implementation_version": "1",
     "description": "VectorXR OpenXR API layer",
     "functions": {

--- a/layer/src/layer_entry.cpp
+++ b/layer/src/layer_entry.cpp
@@ -50,6 +50,10 @@ XrResult XRAPI_CALL DepthxrBeginSession(XrSession session, const XrSessionBeginI
     return OpenXrLayer::Instance().BeginSession(session, begin_info);
 }
 
+XrResult XRAPI_CALL DepthxrEndSession(XrSession session) {
+    return OpenXrLayer::Instance().EndSession(session);
+}
+
 XrResult XRAPI_CALL DepthxrAttachSessionActionSets(XrSession session,
                                                    const XrSessionActionSetsAttachInfo* attach_info) {
     return OpenXrLayer::Instance().AttachSessionActionSets(session, attach_info);
@@ -431,6 +435,10 @@ XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance instance, const char* name,
         *function = reinterpret_cast<PFN_xrVoidFunction>(depthxr::DepthxrBeginSession);
         return XR_SUCCESS;
     }
+    if (requested == "xrEndSession") {
+        *function = reinterpret_cast<PFN_xrVoidFunction>(depthxr::DepthxrEndSession);
+        return XR_SUCCESS;
+    }
     if (requested == "xrAttachSessionActionSets") {
         *function = reinterpret_cast<PFN_xrVoidFunction>(depthxr::DepthxrAttachSessionActionSets);
         return XR_SUCCESS;
@@ -550,6 +558,10 @@ XrResult XRAPI_CALL xrCreateApiLayerInstance(const XrInstanceCreateInfo* instanc
         return XR_ERROR_INITIALIZATION_FAILED;
     }
 
+    if (!OpenXrLayer::Instance().CanCreateInstance()) {
+        return XR_ERROR_LIMIT_REACHED;
+    }
+
     OpenXrLayer::Instance().SetNextProcAddr(next_info->nextGetInstanceProcAddr);
 
     XrApiLayerCreateInfo chain_info = *layer_info;
@@ -563,12 +575,10 @@ XrResult XRAPI_CALL xrCreateApiLayerInstance(const XrInstanceCreateInfo* instanc
     diagnostics.app_requested_eye_gaze =
         ApplicationRequestedExtension(instance_create_info, XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME);
 
-    // Varjo compatible quadviews: when VectorXR quadviews is enabled AND the app
-    // requested quad views AND the runtime natively advertises them, forward the
-    // Varjo extensions to the runtime instead of stripping them for stereo-composite
-    // emulation. This lets the runtime drive the physical focus panels directly. It
-    // is the default on Varjo (no opt-in), and gated on the runtime probe so it is
-    // inert on every non-Varjo headset.
+    // Native Varjo extensions are part of the app/runtime contract, not a VectorXR
+    // feature toggle. Always preserve them for the active Varjo runtime. VectorXR's
+    // profile still decides whether scaling/sharpening modifications are applied,
+    // but disabling Quadviews must never disable an application's native path.
     const bool app_requested_quad_views_for_forwarding =
         diagnostics.app_requested_quad_views || diagnostics.app_requested_varjo_foveated_rendering;
     bool forward_varjo_quad_extensions = false;
@@ -593,15 +603,19 @@ XrResult XRAPI_CALL xrCreateApiLayerInstance(const XrInstanceCreateInfo* instanc
         }
         diagnostics.pre_instance_extensions = std::move(joined_extensions);
 
-        // Drive the decision off the active OpenXR runtime (reliable, no-op off
-        // Varjo) rather than the pre-instance extension probe (kept above only for
-        // diagnostics — it proved to give false negatives on Varjo).
+        // The manifest identity is a fallback for Varjo, whose pre-instance
+        // extension probe can return false negatives. Other runtimes forward
+        // only when they advertise every native extension the app requested.
         std::string active_runtime_path;
         diagnostics.active_runtime_is_varjo = ActiveOpenXrRuntimeIsVarjo(active_runtime_path);
         diagnostics.active_runtime_path = std::move(active_runtime_path);
 
+        const bool runtime_supports_requested_native_extensions =
+            (!diagnostics.app_requested_quad_views || diagnostics.runtime_advertises_varjo_quad) &&
+            (!diagnostics.app_requested_varjo_foveated_rendering ||
+             diagnostics.runtime_advertises_varjo_foveated);
         forward_varjo_quad_extensions =
-            diagnostics.varjo_compatible_eligible && diagnostics.active_runtime_is_varjo;
+            diagnostics.active_runtime_is_varjo || runtime_supports_requested_native_extensions;
     }
     diagnostics.varjo_compatible_quad_forwarded = forward_varjo_quad_extensions;
 
@@ -630,7 +644,8 @@ XrResult XRAPI_CALL xrCreateApiLayerInstance(const XrInstanceCreateInfo* instanc
 
     std::vector<const char*> first_downstream_extensions = base_downstream_extensions;
     diagnostics.optimistic_eye_gaze_request =
-        app_requested_layer_owned_quadviews &&
+        app_requested_layer_owned_quadviews && !forward_varjo_quad_extensions &&
+        diagnostics.cheap_eye_gaze_probe_supported &&
         !ExtensionListContains(first_downstream_extensions, XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME);
     if (diagnostics.optimistic_eye_gaze_request) {
         first_downstream_extensions.push_back(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME);
@@ -646,7 +661,8 @@ XrResult XRAPI_CALL xrCreateApiLayerInstance(const XrInstanceCreateInfo* instanc
     diagnostics.first_create_result = result;
 
     const std::vector<const char*>* successful_downstream_extensions = &first_downstream_extensions;
-    if (XR_FAILED(result) && diagnostics.optimistic_eye_gaze_request) {
+    if ((result == XR_ERROR_EXTENSION_NOT_PRESENT || result == XR_ERROR_EXTENSION_DEPENDENCY_NOT_ENABLED) &&
+        diagnostics.optimistic_eye_gaze_request) {
         diagnostics.retried_without_eye_gaze = true;
         *instance = XR_NULL_HANDLE;
 

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -505,6 +505,12 @@ struct FocusSharpenConstants {
 // halos. Tunable; 3.0 matches the effective radius of the compositor path in testing.
 constexpr float kVarjoFocusSharpenRadiusTexels = 3.0f;
 
+// Frames of continuous "sharpen requested but nothing sharpened" before the skip
+// diagnostic is logged. Filters startup transients (first frames can legitimately
+// skip before the focus swapchains have a released image) so the one-shot log
+// only fires for a persistent condition.
+constexpr uint32_t kFocusSharpenSkipLogFrames = 90;
+
 // Standalone 1:1 CAS sharpen over a focus view. Unlike the compositor shader this
 // does not blend a peripheral view or resample into a sub-rect. Neighbours are taken
 // at a widened offset (params.yz, a few source texels — see kVarjoFocusSharpenRadiusTexels)
@@ -4601,6 +4607,14 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         IsQuadViewsActive() && has_active_primary_view_configuration_ &&
         IsQuadViewConfiguration(active_primary_view_configuration_type_) &&
         active_runtime_view_configuration_type_ == XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    // Varjo compatible quadviews: the focus sharpen runs inside the projection
+    // rewrite loop below, so a requested sharpen must keep this frame out of the
+    // identity-delta fast path — otherwise sharpening only ever ran on frames
+    // where PivotXR happened to produce a correction. Threshold matches
+    // SharpenNativeFocusViews (amount <= 0.001 is treated as off).
+    const bool needs_native_focus_sharpen =
+        varjo_compatible_quadviews_active_ && IsQuadViewsActive() &&
+        Clamp(resolved_settings_.quadviews.foveate_sharpness, 0.0, 100.0) / 100.0 > 0.001;
     const bool should_log_end_frame_diagnostic =
         pending_end_frame_diagnostics_ > 0 ||
         (quadviews_projection_split_active &&
@@ -4664,7 +4678,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         }
     }
 
-    if (!has_non_identity_delta && !quadviews_projection_split_active) {
+    if (!has_non_identity_delta && !quadviews_projection_split_active && !needs_native_focus_sharpen) {
         if (should_log_end_frame_diagnostic) {
             std::ostringstream stream;
             stream << "EndFrame pivot correction skipped: cacheHit=" << has_pose_delta
@@ -7202,6 +7216,8 @@ void OpenXrLayer::ResetD3D11FocusSharpen() {
     d3d11_focus_sharpen_.initialized = false;
     d3d11_focus_sharpen_.failed = false;
     d3d11_focus_sharpen_.has_logged_active = false;
+    d3d11_focus_sharpen_.has_logged_skipped = false;
+    d3d11_focus_sharpen_.consecutive_skipped_frames = 0;
     d3d11_focus_sharpen_.failure_logs_remaining = 8;
 }
 
@@ -7372,6 +7388,15 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         return;
     }
     if (!EnsureD3D11FocusSharpen()) {
+        if (!d3d11_focus_sharpen_.has_logged_skipped) {
+            logger_.Info(std::string("Varjo focus sharpen requested (amount=") +
+                         FormatDiagnosticDouble(sharpen_amount) +
+                         ") but the D3D11 sharpen pass is unavailable: " +
+                         (d3d11_focus_sharpen_.failed
+                              ? "shader/resource initialization failed (see earlier errors)."
+                              : "no D3D11 graphics binding for this session."));
+            d3d11_focus_sharpen_.has_logged_skipped = true;
+        }
         return;
     }
 
@@ -7402,16 +7427,22 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
     context->RSGetViewports(&saved.viewport_count, saved.viewports);
 
     uint32_t sharpened_count = 0;
+    // Why each focus view was skipped, for the one-shot diagnostic below — the
+    // pass otherwise degrades to a silent no-op that looks like a dead slider.
+    const char* skip_reason[2] = {"ok", "ok"};
     for (uint32_t i = 2; i < 4; ++i) {
+        const char*& reason = skip_reason[i - 2];
         XrCompositionLayerProjectionView& view = views[i];
         // Only single-slice focus swapchains are supported for the sharpen pass; an
         // arrayed subImage falls back to the app's unsharpened focus.
         if (view.subImage.imageArrayIndex != 0 || view.subImage.swapchain == XR_NULL_HANDLE) {
+            reason = "arrayed or null subImage";
             continue;
         }
         const auto it = tracked_swapchains_.find(view.subImage.swapchain);
         if (it == tracked_swapchains_.end() || it->second.d3d11_images.empty() ||
             !(it->second.has_last_acquired_image_index || it->second.has_last_released_image_index)) {
+            reason = "swapchain untracked or no acquired image yet";
             continue;
         }
         SwapchainInfo& src = it->second;
@@ -7420,14 +7451,17 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         const uint32_t src_index = src.has_last_released_image_index ? src.last_released_image_index
                                                                      : src.last_acquired_image_index;
         if (src_index >= src.d3d11_images.size()) {
+            reason = "image index out of range";
             continue;
         }
         if (!EnsureD3D11SwapchainShaderResources(src) ||
             src_index >= src.d3d11_shader_resources.size()) {
+            reason = "no shader resource views (focus swapchain needs sampled usage)";
             continue;
         }
         ID3D11ShaderResourceView* focus_srv = src.d3d11_shader_resources[src_index];
         if (!focus_srv) {
+            reason = "null shader resource view";
             continue;
         }
 
@@ -7435,6 +7469,7 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         const uint32_t out_height = static_cast<uint32_t>(view.subImage.imageRect.extent.height);
         QuadViewsCompositionTarget& target = d3d11_focus_sharpen_.targets[i - 2];
         if (!EnsureFocusSharpenTarget(target, out_width, out_height, src.format)) {
+            reason = "sharpen output swapchain unavailable";
             continue;
         }
 
@@ -7442,6 +7477,7 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         XrSwapchainImageAcquireInfo acquire_info{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
         XrResult result = next_acquire_swapchain_image_(target.swapchain, &acquire_info, &output_index);
         if (XR_FAILED(result) || output_index >= target.image_render_target_views.size()) {
+            reason = "sharpen output acquire failed";
             continue;
         }
         XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
@@ -7450,6 +7486,7 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         if (XR_FAILED(result)) {
             XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
             next_release_swapchain_image_(target.swapchain, &release_info);
+            reason = "sharpen output wait failed";
             continue;
         }
 
@@ -7497,6 +7534,7 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
         result = next_release_swapchain_image_(target.swapchain, &release_info);
         if (XR_FAILED(result)) {
+            reason = "sharpen output release failed";
             continue;
         }
 
@@ -7535,13 +7573,27 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         SafeRelease(buffer);
     }
 
-    if (sharpened_count > 0 && !d3d11_focus_sharpen_.has_logged_active) {
-        logger_.Info("D3D11 focus sharpen active in Varjo compatible quadviews: sharpened " +
-                     std::to_string(sharpened_count) + " focus view(s), amount=" +
-                     FormatDiagnosticDouble(sharpen_amount) + ", radiusTexels=" +
-                     FormatDiagnosticDouble(kVarjoFocusSharpenRadiusTexels) +
-                     " (frameTime=" + std::to_string(display_time) + ").");
-        d3d11_focus_sharpen_.has_logged_active = true;
+    if (sharpened_count > 0) {
+        d3d11_focus_sharpen_.consecutive_skipped_frames = 0;
+        if (!d3d11_focus_sharpen_.has_logged_active) {
+            logger_.Info("D3D11 focus sharpen active in Varjo compatible quadviews: sharpened " +
+                         std::to_string(sharpened_count) + " focus view(s), amount=" +
+                         FormatDiagnosticDouble(sharpen_amount) + ", radiusTexels=" +
+                         FormatDiagnosticDouble(kVarjoFocusSharpenRadiusTexels) +
+                         " (frameTime=" + std::to_string(display_time) + ").");
+            d3d11_focus_sharpen_.has_logged_active = true;
+        }
+    } else {
+        ++d3d11_focus_sharpen_.consecutive_skipped_frames;
+        if (!d3d11_focus_sharpen_.has_logged_skipped &&
+            d3d11_focus_sharpen_.consecutive_skipped_frames >= kFocusSharpenSkipLogFrames) {
+            logger_.Info(std::string("Varjo focus sharpen requested (amount=") +
+                         FormatDiagnosticDouble(sharpen_amount) + ") but no focus view was sharpened for " +
+                         std::to_string(d3d11_focus_sharpen_.consecutive_skipped_frames) +
+                         " consecutive frames: view2=[" + skip_reason[0] + "], view3=[" + skip_reason[1] +
+                         "] (frameTime=" + std::to_string(display_time) + ").");
+            d3d11_focus_sharpen_.has_logged_skipped = true;
+        }
     }
 }
 

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <d3d11.h>
+#include <d3d11_1.h>
 #include <d3dcompiler.h>
 #include <openxr/openxr_platform.h>
 
@@ -43,9 +44,18 @@ bool NearlyEqual(double lhs, double rhs) {
 // field reports on Oculus and Varjo; PiOpenXR observed during development);
 // runtimes with async pipelining confirmed stable in the field start async.
 // Unknown runtimes return nullopt and are probed async-first.
-std::optional<TurboPacingMode> SeededTurboPacingMode(const std::string& runtime_name) {
+std::optional<TurboPacingMode> SeededTurboPacingMode(const std::string& runtime_name,
+                                                     const std::string& system_name) {
     for (const char* fragment : {"Oculus", "Varjo", "PiOpenXR", "Pimax"}) {
         if (runtime_name.find(fragment) != std::string::npos) {
+            return TurboPacingMode::kSequenced;
+        }
+    }
+    // SteamVR's pacing behavior also depends on its active headset driver.
+    // Pimax's SteamVR driver interlocks waits like PiOpenXR, so do not replay
+    // the async probe merely because the outer runtime identifies as SteamVR.
+    for (const char* fragment : {"Pimax", "Crystal"}) {
+        if (system_name.find(fragment) != std::string::npos) {
             return TurboPacingMode::kSequenced;
         }
     }
@@ -276,6 +286,7 @@ std::string FormatTextureDesc(const D3D11_TEXTURE2D_DESC& desc) {
 HRESULT CreateTextureShaderResourceView(ID3D11Device* device,
                                         ID3D11Texture2D* texture,
                                         int64_t fallback_format,
+                                        uint32_t array_slice,
                                         ID3D11ShaderResourceView** shader_resource) {
     if (!device || !texture || !shader_resource) {
         return E_INVALIDARG;
@@ -283,15 +294,25 @@ HRESULT CreateTextureShaderResourceView(ID3D11Device* device,
 
     D3D11_TEXTURE2D_DESC texture_desc{};
     texture->GetDesc(&texture_desc);
-    if ((texture_desc.BindFlags & D3D11_BIND_SHADER_RESOURCE) == 0 || texture_desc.ArraySize != 1 ||
-        texture_desc.MipLevels == 0) {
+    if ((texture_desc.BindFlags & D3D11_BIND_SHADER_RESOURCE) == 0 || texture_desc.MipLevels == 0 ||
+        array_slice >= texture_desc.ArraySize) {
         return E_INVALIDARG;
     }
 
     D3D11_SHADER_RESOURCE_VIEW_DESC view_desc{};
     view_desc.Format = ResolveViewFormat(texture_desc.Format, fallback_format);
-    if (texture_desc.SampleDesc.Count > 1) {
+    if (texture_desc.SampleDesc.Count > 1 && texture_desc.ArraySize > 1) {
+        view_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
+        view_desc.Texture2DMSArray.FirstArraySlice = array_slice;
+        view_desc.Texture2DMSArray.ArraySize = 1;
+    } else if (texture_desc.SampleDesc.Count > 1) {
         view_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMS;
+    } else if (texture_desc.ArraySize > 1) {
+        view_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+        view_desc.Texture2DArray.MostDetailedMip = 0;
+        view_desc.Texture2DArray.MipLevels = 1;
+        view_desc.Texture2DArray.FirstArraySlice = array_slice;
+        view_desc.Texture2DArray.ArraySize = 1;
     } else {
         view_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
         view_desc.Texture2D.MostDetailedMip = 0;
@@ -364,6 +385,8 @@ struct FocusRectConstants {
     float focus_rect[4];
     float blend_params[4];
     float focus_texel[4];
+    float peripheral_src_rect[4];
+    float focus_src_rect[4];
 };
 
 FocusRectConstants BuildFocusRectConstants(const XrFovf& full_fov,
@@ -411,6 +434,14 @@ FocusRectConstants BuildFocusRectConstants(const XrFovf& full_fov,
         static_cast<float>((1.0 / std::max<uint32_t>(1, width)) / focus_rect_width);
     constants.focus_texel[3] =
         static_cast<float>((1.0 / std::max<uint32_t>(1, height)) / focus_rect_height);
+    constants.peripheral_src_rect[0] = 0.0f;
+    constants.peripheral_src_rect[1] = 0.0f;
+    constants.peripheral_src_rect[2] = 1.0f;
+    constants.peripheral_src_rect[3] = 1.0f;
+    constants.focus_src_rect[0] = 0.0f;
+    constants.focus_src_rect[1] = 0.0f;
+    constants.focus_src_rect[2] = 1.0f;
+    constants.focus_src_rect[3] = 1.0f;
     return constants;
 }
 
@@ -420,6 +451,8 @@ cbuffer QuadViewsConstants : register(b0) {
     float4 focusRect;
     float4 blendParams;
     float4 focusTexel;
+    float4 peripheralSrcRect;
+    float4 focusSrcRect;
 };
 
 Texture2D peripheralTexture : register(t0);
@@ -451,7 +484,8 @@ VSOut VSMain(uint vertexId : SV_VertexID) {
 
 float4 PSMain(VSOut input) : SV_Target {
     float2 uv = saturate(input.uv);
-    float4 peripheral = peripheralTexture.Sample(linearSampler, uv);
+    float2 peripheralUv = peripheralSrcRect.xy + uv * peripheralSrcRect.zw;
+    float4 peripheral = peripheralTexture.Sample(linearSampler, peripheralUv);
 
     float2 inside = step(focusRect.xy, uv) * step(uv, focusRect.zw);
     float inRect = inside.x * inside.y;
@@ -460,18 +494,21 @@ float4 PSMain(VSOut input) : SV_Target {
     }
 
     float2 focusUv = saturate((uv - focusRect.xy) / max(focusRect.zw - focusRect.xy, float2(0.0001, 0.0001)));
-    float4 focus = focusTexture.Sample(linearSampler, focusUv);
+    float2 focusSampleUv = focusSrcRect.xy + focusUv * focusSrcRect.zw;
+    float2 focusSampleMin = focusSrcRect.xy;
+    float2 focusSampleMax = focusSrcRect.xy + focusSrcRect.zw;
+    float4 focus = focusTexture.Sample(linearSampler, focusSampleUv);
     float sharpenAmount = saturate(blendParams.z);
     if (sharpenAmount > 0.001) {
         // Sample neighbors at output-pixel spacing (focusTexel.zw is one output pixel expressed
         // in focus-UV), not focus-texel spacing. The focus texture is minified into the focus
         // rect, so a focus-texel-scale unsharp mask synthesizes detail that the resample averages
         // away; output-space offsets target the frequencies the user actually sees.
-        float2 off = focusTexel.zw;
-        float3 n = focusTexture.Sample(linearSampler, saturate(focusUv + float2(0.0, -off.y))).rgb;
-        float3 s = focusTexture.Sample(linearSampler, saturate(focusUv + float2(0.0,  off.y))).rgb;
-        float3 e = focusTexture.Sample(linearSampler, saturate(focusUv + float2( off.x, 0.0))).rgb;
-        float3 w = focusTexture.Sample(linearSampler, saturate(focusUv + float2(-off.x, 0.0))).rgb;
+        float2 off = focusTexel.zw * focusSrcRect.zw;
+        float3 n = focusTexture.Sample(linearSampler, clamp(focusSampleUv + float2(0.0, -off.y), focusSampleMin, focusSampleMax)).rgb;
+        float3 s = focusTexture.Sample(linearSampler, clamp(focusSampleUv + float2(0.0,  off.y), focusSampleMin, focusSampleMax)).rgb;
+        float3 e = focusTexture.Sample(linearSampler, clamp(focusSampleUv + float2( off.x, 0.0), focusSampleMin, focusSampleMax)).rgb;
+        float3 w = focusTexture.Sample(linearSampler, clamp(focusSampleUv + float2(-off.x, 0.0), focusSampleMin, focusSampleMax)).rgb;
         float3 avg = (n + s + e + w) * 0.25;
         float3 sharpened = focus.rgb + (focus.rgb - avg) * sharpenAmount;
         // CAS-style clamp: keep the result inside the local neighborhood range so strong
@@ -995,7 +1032,9 @@ bool IsQuadViewConfiguration(XrViewConfigurationType type) {
 constexpr double kPivotActivationGainEpsilon = 0.0001;
 constexpr XrTime kMaxPivotPoseDeltaMatchWindow = 5'000'000;
 constexpr XrTime kMaxQuadViewsFovMatchWindow = 5'000'000;
+constexpr size_t kMaxCachedPivotPoseFrames = 180;
 constexpr size_t kMaxCachedQuadViewsFovFrames = 180;
+constexpr XrDuration kInternalSwapchainWaitTimeout = 100'000'000; // 100 ms
 constexpr uint32_t kPivotDiagnosticBurstCount = 8;
 constexpr uint64_t kPivotDiagnosticStride = 120;
 // Consecutive unavailable frames before the eye-gaze focus is logged as lost.
@@ -1170,6 +1209,8 @@ OpenXrLayer::~OpenXrLayer() {
     // terminate(). The watcher only touches this object's own members, all of
     // which outlive this destructor body.
     StopConfigWatcher();
+    StopTurboAsyncWorker();
+    DrainRuntimePacingWrites();
 }
 
 void OpenXrLayer::SetLayerDirectory(std::filesystem::path dll_directory) {
@@ -1180,6 +1221,11 @@ void OpenXrLayer::SetLayerDirectory(std::filesystem::path dll_directory) {
 void OpenXrLayer::SetNextProcAddr(PFN_xrGetInstanceProcAddr next_get_instance_proc_addr) {
     std::scoped_lock lock(mutex_);
     next_get_instance_proc_addr_ = next_get_instance_proc_addr;
+}
+
+bool OpenXrLayer::CanCreateInstance() {
+    std::scoped_lock lock(mutex_);
+    return instance_ == XR_NULL_HANDLE;
 }
 
 XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
@@ -1206,6 +1252,8 @@ XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
             ExtensionRequested(create_info, XR_VARJO_QUAD_VIEWS_EXTENSION_NAME);
         varjo_foveated_rendering_extension_requested_ =
             ExtensionRequested(create_info, XR_VARJO_FOVEATED_RENDERING_EXTENSION_NAME);
+        d3d11_graphics_extension_requested_ =
+            ExtensionRequested(create_info, XR_KHR_D3D11_ENABLE_EXTENSION_NAME);
 
         std::ostringstream stream;
         const XrVersion api_version = create_info->applicationInfo.apiVersion;
@@ -1233,11 +1281,9 @@ XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
     }
     if (varjo_compatible_quadviews_active_) {
         logger_.Info(
-            "Quadviews Varjo compatible mode ACTIVE: forwarded native quad views to the runtime so the "
-            "focus panels are driven directly; stereo composite and quad->stereo synthesis are disabled "
-            "for this instance. Applied knobs: focusScale/peripheralScale (view resolution) and "
-            "foveateSharpness (focus CAS post-process, runs only when > 0). Runtime-owned in this mode: "
-            "focus size, transition, offsets, gaze smoothing/deadzone.");
+            "Native Varjo quadviews forwarding ACTIVE: the app/runtime quad-view contract is preserved "
+            "independently of VectorXR profiles. When VectorXR Quadviews resolves enabled, it may apply "
+            "focus/peripheral resolution scaling and focus sharpening; otherwise this path is transparent.");
     } else if (quad_views_extension_requested_ || varjo_foveated_rendering_extension_requested_) {
         logger_.Info(
             "Quadviews mode: stereo-composite emulation (Varjo compatible mode not active — runtime lacks "
@@ -1310,6 +1356,7 @@ XrResult OpenXrLayer::OnInstanceCreated(const XrInstanceCreateInfo* create_info,
 
     CaptureInstanceFunctions();
     if (!next_destroy_instance_ || !next_create_session_ || !next_destroy_session_ || !next_begin_session_ ||
+        !next_end_session_ ||
         !next_attach_session_action_sets_ || !next_sync_actions_ ||
         !next_end_frame_ || !next_get_system_properties_ || !next_enumerate_environment_blend_modes_ ||
         !next_enumerate_view_configurations_ || !next_get_view_configuration_properties_ ||
@@ -1379,6 +1426,7 @@ XrResult OpenXrLayer::DestroyInstance(XrInstance instance) {
     // Join the watcher before taking mutex_: it may be mid-PollConfigFile
     // holding the lock, so stopping it under mutex_ would deadlock.
     StopConfigWatcher();
+    StopTurboAsyncWorker();
 
     std::scoped_lock lock(mutex_);
 
@@ -1392,6 +1440,7 @@ XrResult OpenXrLayer::DestroyInstance(XrInstance instance) {
         next_create_session_ = nullptr;
         next_destroy_session_ = nullptr;
         next_begin_session_ = nullptr;
+        next_end_session_ = nullptr;
         next_attach_session_action_sets_ = nullptr;
         next_sync_actions_ = nullptr;
         next_get_system_properties_ = nullptr;
@@ -1411,6 +1460,8 @@ XrResult OpenXrLayer::DestroyInstance(XrInstance instance) {
         next_create_reference_space_ = nullptr;
         next_create_action_space_ = nullptr;
         next_destroy_space_ = nullptr;
+        next_wait_frame_ = nullptr;
+        next_begin_frame_ = nullptr;
         next_end_frame_ = nullptr;
         next_locate_space_ = nullptr;
         next_locate_views_ = nullptr;
@@ -1438,6 +1489,14 @@ XrResult OpenXrLayer::CreateSession(XrInstance instance,
                                     const XrSessionCreateInfo* create_info,
                                     XrSession* session) {
     {
+        std::scoped_lock lock(mutex_);
+        if (active_session_ != XR_NULL_HANDLE) {
+            logger_.Error("VectorXR currently supports one OpenXR session per instance; rejecting a second "
+                          "session instead of corrupting the active session state.");
+            return XR_ERROR_LIMIT_REACHED;
+        }
+    }
+    {
         const void* graphics_binding = create_info ? create_info->next : nullptr;
         const auto* next_struct = static_cast<const XrBaseInStructure*>(graphics_binding);
         logger_.Info(std::string("xrCreateSession requested by application: graphicsBindingType=") +
@@ -1460,13 +1519,39 @@ XrResult OpenXrLayer::CreateSession(XrInstance instance,
                                     ? static_cast<const XrGraphicsBindingD3D11KHR*>(
                                           FindStructInChain(create_info->next, XR_TYPE_GRAPHICS_BINDING_D3D11_KHR))
                                     : nullptr;
+    graphics_api_ = d3d11_binding && d3d11_binding->device ? "D3D11" : "Other";
     if (d3d11_binding && d3d11_binding->device) {
         d3d11_quadviews_compositor_.device = d3d11_binding->device;
         d3d11_quadviews_compositor_.device->AddRef();
         d3d11_quadviews_compositor_.device->GetImmediateContext(&d3d11_quadviews_compositor_.context);
+        ID3D11Device1* device1 = nullptr;
+        if (d3d11_quadviews_compositor_.context &&
+            SUCCEEDED(d3d11_quadviews_compositor_.device->QueryInterface(
+                __uuidof(ID3D11Device1), reinterpret_cast<void**>(&device1))) &&
+            SUCCEEDED(d3d11_quadviews_compositor_.context->QueryInterface(
+                __uuidof(ID3D11DeviceContext1),
+                reinterpret_cast<void**>(&d3d11_quadviews_compositor_.context1)))) {
+            UINT context_flags = 0;
+            if ((d3d11_quadviews_compositor_.device->GetCreationFlags() & D3D11_CREATE_DEVICE_SINGLETHREADED) != 0) {
+                context_flags |= D3D11_1_CREATE_DEVICE_CONTEXT_STATE_SINGLETHREADED;
+            }
+            const D3D_FEATURE_LEVEL feature_level = d3d11_quadviews_compositor_.device->GetFeatureLevel();
+            const HRESULT state_result = device1->CreateDeviceContextState(
+                context_flags,
+                &feature_level,
+                1,
+                D3D11_SDK_VERSION,
+                __uuidof(ID3D11Device),
+                nullptr,
+                &d3d11_quadviews_compositor_.layer_context_state);
+            if (FAILED(state_result)) {
+                SafeRelease(d3d11_quadviews_compositor_.context1);
+            }
+        }
+        SafeRelease(device1);
         logger_.Info("D3D11 graphics binding detected; native quadviews compositor is available.");
     } else {
-        logger_.Info("D3D11 graphics binding not detected; native quadviews compositor will use fallback split path.");
+        logger_.Info("D3D11 graphics binding not detected; synthesized quadviews is unavailable for this session.");
     }
     const XrResult internal_result = CreateInternalReferenceSpaces(*session);
     if (XR_FAILED(internal_result)) {
@@ -1475,7 +1560,8 @@ XrResult OpenXrLayer::CreateSession(XrInstance instance,
     }
     ReloadConfigIfNeeded();
     RefreshResolvedSettings();
-    if (IsQuadViewsActive() && resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye) {
+    if (IsQuadViewsEmulationActive() &&
+        resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye) {
         const XrResult eye_gaze_result = CreateEyeGazeResources(*session);
         if (XR_FAILED(eye_gaze_result)) {
             logger_.Info("Eye gaze resources unavailable; quadviews will use head/static focus offsets.");
@@ -1512,12 +1598,12 @@ XrResult OpenXrLayer::DestroySession(XrSession session) {
 }
 
 XrResult OpenXrLayer::BeginSession(XrSession session, const XrSessionBeginInfo* begin_info) {
-    bool quadviews_active = false;
+    bool quadviews_emulation_active = false;
     {
         std::scoped_lock lock(mutex_);
         ReloadConfigIfNeeded();
         RefreshResolvedSettings();
-        quadviews_active = IsQuadViewsActive();
+        quadviews_emulation_active = IsQuadViewsEmulationActive();
     }
 
     XrSessionBeginInfo runtime_begin_info{};
@@ -1525,8 +1611,8 @@ XrResult OpenXrLayer::BeginSession(XrSession session, const XrSessionBeginInfo* 
     // In Varjo compatible mode the runtime supports the quad configuration itself, so
     // begin the session on the app's real config and let the runtime drive the
     // focus panels. Only remap to stereo when we are emulating.
-    if (begin_info && IsQuadViewConfiguration(begin_info->primaryViewConfigurationType) && quadviews_active &&
-        !varjo_compatible_quadviews_active_) {
+    if (begin_info && IsQuadViewConfiguration(begin_info->primaryViewConfigurationType) &&
+        quadviews_emulation_active) {
         runtime_begin_info = *begin_info;
         runtime_begin_info.primaryViewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
         downstream_begin_info = &runtime_begin_info;
@@ -1574,6 +1660,85 @@ XrResult OpenXrLayer::BeginSession(XrSession session, const XrSessionBeginInfo* 
                 "enabling quadviews.");
         }
     }
+    return result;
+}
+
+XrResult OpenXrLayer::EndSession(XrSession session) {
+    // Turbo deliberately pre-waits (and, in sequenced mode, pre-begins) the
+    // following frame. Balance that owned frame before ending the session so a
+    // later xrBeginSession starts from a clean runtime call-order state.
+    DrainTurboAsyncWait();
+
+    bool begin_pending_frame = false;
+    bool end_pending_frame = false;
+    XrTime display_time = 0;
+    XrEnvironmentBlendMode blend_mode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    {
+        std::scoped_lock lock(turbo_mutex_);
+        const bool async_wait_succeeded = turbo_async_wait_.valid() && turbo_async_wait_completed_ &&
+                                          XR_SUCCEEDED(turbo_async_wait_result_);
+        begin_pending_frame = (async_wait_succeeded && !turbo_frame_begun_) || turbo_begin_owed_;
+        end_pending_frame = turbo_frame_begun_ || begin_pending_frame;
+        display_time = turbo_last_predicted_display_time_;
+        blend_mode = turbo_last_environment_blend_mode_;
+        turbo_begin_owed_ = false;
+    }
+
+    if (begin_pending_frame) {
+        const XrResult begin_result = next_begin_frame_(session, nullptr);
+        if (XR_FAILED(begin_result)) {
+            logger_.Info("Session end: unable to balance Turbo's pending xrBeginFrame, result=" +
+                         std::to_string(static_cast<int>(begin_result)) + ".");
+            end_pending_frame = false;
+        }
+    }
+    if (end_pending_frame) {
+        XrFrameEndInfo empty_end{XR_TYPE_FRAME_END_INFO};
+        empty_end.displayTime = display_time;
+        empty_end.environmentBlendMode = blend_mode;
+        empty_end.layerCount = 0;
+        empty_end.layers = nullptr;
+        const XrResult end_result = next_end_frame_(session, &empty_end);
+        if (XR_FAILED(end_result)) {
+            logger_.Info("Session end: unable to balance Turbo's pending empty frame, result=" +
+                         std::to_string(static_cast<int>(end_result)) + ".");
+        } else {
+            std::scoped_lock lock(turbo_mutex_);
+            turbo_frame_begun_ = false;
+            turbo_async_wait_ = {};
+            ++turbo_async_wait_generation_;
+        }
+    }
+
+    const XrResult result = next_end_session_(session);
+    if (XR_FAILED(result)) {
+        logger_.Error("xrEndSession failed downstream: result=" +
+                      std::to_string(static_cast<int>(result)));
+        return result;
+    }
+
+    ResetTurboFrameState();
+    {
+        std::scoped_lock lock(mutex_);
+        session_begin_wall_time_.reset();
+        active_primary_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+        active_runtime_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+        has_active_primary_view_configuration_ = false;
+        cached_eye_offset_poses_.clear();
+        cached_eye_offsets_display_time_ = 0;
+        cached_pivot_pose_deltas_.clear();
+        cached_quadviews_fovs_.clear();
+        last_app_action_sync_time_.reset();
+        last_eye_gaze_self_sync_time_.reset();
+        quadviews_smoothed_focus_yaw_radians_ = 0.0;
+        quadviews_smoothed_focus_pitch_radians_ = 0.0;
+        quadviews_last_focus_smoothing_wall_time_.reset();
+        quadviews_last_valid_gaze_wall_time_.reset();
+        ResetPivotActivationState();
+        ResetDepthToggleState();
+        ResetTurboToggleState();
+    }
+    logger_.Info("OpenXR session ended; VectorXR frame and tracking state reset for restart.");
     return result;
 }
 
@@ -1689,6 +1854,8 @@ XrResult OpenXrLayer::GetSystemProperties(XrInstance instance,
     std::scoped_lock lock(mutex_);
     ReloadConfigIfNeeded();
     RefreshResolvedSettings();
+    system_name_ = properties->systemName;
+    system_vendor_id_ = properties->vendorId;
 
     const bool app_queried_varjo_foveation =
         FindStructInChain(properties->next, XR_TYPE_SYSTEM_FOVEATED_RENDERING_PROPERTIES_VARJO) != nullptr;
@@ -1730,7 +1897,7 @@ XrResult OpenXrLayer::EnumerateEnvironmentBlendModes(
     ReloadConfigIfNeeded();
     RefreshResolvedSettings();
     const XrViewConfigurationType runtime_type =
-        IsQuadViewConfiguration(view_configuration_type) && IsQuadViewsActive()
+        IsQuadViewConfiguration(view_configuration_type) && IsQuadViewsEmulationActive()
             ? XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO
             : view_configuration_type;
     return next_enumerate_environment_blend_modes_(instance,
@@ -1784,7 +1951,7 @@ XrResult OpenXrLayer::EnumerateViewConfigurations(XrInstance instance,
     const bool quadviews_active = IsQuadViewsActive();
     const bool app_requested_quadviews =
         quad_views_extension_requested_ || varjo_foveated_rendering_extension_requested_;
-    const bool synthesize_quad = quadviews_active && runtime_has_stereo && !runtime_has_quad;
+    const bool synthesize_quad = IsQuadViewsEmulationActive() && runtime_has_stereo && !runtime_has_quad;
     const bool prefer_quad_first = quadviews_active && app_requested_quadviews;
 
     if (synthesize_quad) {
@@ -1838,8 +2005,8 @@ XrResult OpenXrLayer::GetViewConfigurationProperties(
     std::scoped_lock lock(mutex_);
     ReloadConfigIfNeeded();
     RefreshResolvedSettings();
-    const bool synthesize_quad = IsQuadViewConfiguration(view_configuration_type) && IsQuadViewsActive() &&
-                                 !varjo_compatible_quadviews_active_;
+    const bool synthesize_quad =
+        IsQuadViewConfiguration(view_configuration_type) && IsQuadViewsEmulationActive();
     const XrViewConfigurationType runtime_type =
         synthesize_quad ? XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO : view_configuration_type;
 
@@ -2155,8 +2322,8 @@ XrResult OpenXrLayer::EnumerateSwapchainImages(XrSwapchain swapchain,
         it->second.images_enumerated = true;
         it->second.d3d11_images.clear();
         SafeReleaseVector(it->second.d3d11_shader_resources);
-        it->second.d3d11_shader_resources_attempted = false;
-        it->second.d3d11_shader_resources_available = false;
+        it->second.d3d11_shader_resource_slices_attempted.clear();
+        it->second.d3d11_shader_resource_slices_available.clear();
         it->second.d3d11_images.reserve(*image_count_output);
         if (IsD3D11SwapchainImage(images)) {
             const auto* d3d11_images = reinterpret_cast<const XrSwapchainImageD3D11KHR*>(images);
@@ -2213,6 +2380,7 @@ XrResult OpenXrLayer::AcquireSwapchainImage(XrSwapchain swapchain,
         if (index) {
             it->second.last_acquired_image_index = *index;
             it->second.has_last_acquired_image_index = true;
+            it->second.image_states.Acquire(*index);
         }
         if (it->second.quadviews_session && it->second.acquire_count <= 3) {
             LogSwapchainSummary(swapchain, it->second, "acquired");
@@ -2244,6 +2412,7 @@ XrResult OpenXrLayer::WaitSwapchainImage(XrSwapchain swapchain, const XrSwapchai
     const auto it = tracked_swapchains_.find(swapchain);
     if (it != tracked_swapchains_.end()) {
         ++it->second.wait_count;
+        it->second.image_states.WaitOldest();
     }
     return result;
 }
@@ -2257,12 +2426,12 @@ XrResult OpenXrLayer::ReleaseSwapchainImage(XrSwapchain swapchain,
             // Snapshot the released image index at the app's release moment —
             // the compositor must sample this frame's image even after the
             // (turbo-pipelined) app has acquired the next one.
-            if (it->second.has_last_acquired_image_index) {
-                it->second.last_released_image_index = it->second.last_acquired_image_index;
+            if (const std::optional<uint32_t> released_index = it->second.image_states.ReleaseOldest()) {
+                it->second.last_released_image_index = *released_index;
                 it->second.has_last_released_image_index = true;
             }
             if (ShouldDeferSwapchainRelease(it->second)) {
-                it->second.release_deferred = true;
+                ++it->second.deferred_release_count;
                 ++it->second.release_count;
                 if (it->second.quadviews_session && it->second.release_count <= 3) {
                     LogSwapchainSummary(swapchain, it->second, "releaseDeferred");
@@ -2289,6 +2458,7 @@ XrResult OpenXrLayer::ReleaseSwapchainImage(XrSwapchain swapchain,
     const auto it = tracked_swapchains_.find(swapchain);
     if (it != tracked_swapchains_.end()) {
         ++it->second.release_count;
+        it->second.image_states.ReleaseDownstreamOldest();
         if (it->second.quadviews_session && it->second.release_count <= 3) {
             LogSwapchainSummary(swapchain, it->second, "released");
         }
@@ -2592,34 +2762,36 @@ bool OpenXrLayer::EnsureD3D11QuadViewsCompositor(const XrCompositionLayerProject
     return true;
 }
 
-bool OpenXrLayer::EnsureD3D11SwapchainShaderResources(SwapchainInfo& swapchain) {
+bool OpenXrLayer::EnsureD3D11SwapchainShaderResources(SwapchainInfo& swapchain,
+                                                       uint32_t array_slice) {
     if (!d3d11_quadviews_compositor_.device ||
         (swapchain.usage_flags & XR_SWAPCHAIN_USAGE_SAMPLED_BIT) == 0 ||
-        swapchain.d3d11_images.empty()) {
+        swapchain.d3d11_images.empty() || swapchain.array_size != 1 || array_slice != 0) {
+        // The compositor shader consumes Texture2D resources. Array slices use
+        // the CopySubresourceRegion fast fallback below, which flattens only
+        // the selected slice without copying the rest of the array.
         return false;
     }
-    if (swapchain.d3d11_shader_resources_attempted) {
-        return swapchain.d3d11_shader_resources_available;
+    if (swapchain.d3d11_shader_resource_slices_attempted.contains(array_slice)) {
+        return swapchain.d3d11_shader_resource_slices_available.contains(array_slice);
     }
-    swapchain.d3d11_shader_resources_attempted = true;
-    if (swapchain.d3d11_shader_resources.size() == swapchain.d3d11_images.size()) {
-        const bool all_ready = std::all_of(swapchain.d3d11_shader_resources.begin(),
-                                           swapchain.d3d11_shader_resources.end(),
-                                           [](ID3D11ShaderResourceView* view) { return view != nullptr; });
-        if (all_ready) {
-            swapchain.d3d11_shader_resources_available = true;
-            return true;
-        }
+    swapchain.d3d11_shader_resource_slices_attempted.insert(array_slice);
+
+    const size_t array_size = std::max<uint32_t>(1, swapchain.array_size);
+    const size_t required_slots = swapchain.d3d11_images.size() * array_size;
+    if (swapchain.d3d11_shader_resources.size() != required_slots) {
         SafeReleaseVector(swapchain.d3d11_shader_resources);
+        swapchain.d3d11_shader_resources.resize(required_slots, nullptr);
+        swapchain.d3d11_shader_resource_slices_available.clear();
     }
 
-    uint32_t image_index = 0;
-    swapchain.d3d11_shader_resources.reserve(swapchain.d3d11_images.size());
-    for (ID3D11Texture2D* texture : swapchain.d3d11_images) {
+    for (uint32_t image_index = 0; image_index < swapchain.d3d11_images.size(); ++image_index) {
+        ID3D11Texture2D* texture = swapchain.d3d11_images[image_index];
         ID3D11ShaderResourceView* shader_resource = nullptr;
         HRESULT hr = CreateTextureShaderResourceView(d3d11_quadviews_compositor_.device,
                                                      texture,
                                                      swapchain.format,
+                                                     array_slice,
                                                      &shader_resource);
         if (FAILED(hr)) {
             D3D11_TEXTURE2D_DESC texture_desc{};
@@ -2627,29 +2799,28 @@ bool OpenXrLayer::EnsureD3D11SwapchainShaderResources(SwapchainInfo& swapchain) 
                 texture->GetDesc(&texture_desc);
             }
             SafeRelease(shader_resource);
-            SafeReleaseVector(swapchain.d3d11_shader_resources);
+            for (uint32_t release_image = 0; release_image < swapchain.d3d11_images.size(); ++release_image) {
+                SafeRelease(swapchain.d3d11_shader_resources[release_image * array_size + array_slice]);
+            }
             logger_.Info("D3D11 quadviews compositor direct input SRVs unavailable; using input copy path. "
                          "hr=" + FormatHex(static_cast<uint32_t>(hr)) +
-                         ", failedImage=" + std::to_string(image_index) +
+                          ", failedImage=" + std::to_string(image_index) +
+                          ", arraySlice=" + std::to_string(array_slice) +
                          ", format=" + std::to_string(swapchain.format) +
                          ", size=" + std::to_string(swapchain.width) + "x" + std::to_string(swapchain.height) +
                          ", usage=" + FormatUsageFlags(swapchain.usage_flags) +
                          ", " + FormatTextureDesc(texture_desc));
-            swapchain.d3d11_shader_resources_available = false;
             return false;
         }
-        swapchain.d3d11_shader_resources.push_back(shader_resource);
-        ++image_index;
+        swapchain.d3d11_shader_resources[image_index * array_size + array_slice] = shader_resource;
     }
-    swapchain.d3d11_shader_resources_available =
-        swapchain.d3d11_shader_resources.size() == swapchain.d3d11_images.size();
-    if (swapchain.d3d11_shader_resources_available) {
-        logger_.Debug("D3D11 quadviews compositor direct input SRVs ready: size=" +
-                      std::to_string(swapchain.width) + "x" + std::to_string(swapchain.height) +
-                      ", images=" + std::to_string(swapchain.d3d11_shader_resources.size()) +
-                      ", format=" + std::to_string(swapchain.format));
-    }
-    return swapchain.d3d11_shader_resources_available;
+    swapchain.d3d11_shader_resource_slices_available.insert(array_slice);
+    logger_.Debug("D3D11 quadviews compositor direct input SRVs ready: size=" +
+                  std::to_string(swapchain.width) + "x" + std::to_string(swapchain.height) +
+                  ", images=" + std::to_string(swapchain.d3d11_images.size()) +
+                  ", arraySlice=" + std::to_string(array_slice) +
+                  ", format=" + std::to_string(swapchain.format));
+    return true;
 }
 
 void OpenXrLayer::TryPrewarmD3D11QuadViewsCompositor() {
@@ -2730,7 +2901,8 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         const auto it = tracked_swapchains_.find(source_layer->views[i].subImage.swapchain);
         if (it == tracked_swapchains_.end() || it->second.d3d11_images.empty() ||
             !(it->second.has_last_acquired_image_index || it->second.has_last_released_image_index) ||
-            source_image_index(it->second) >= it->second.d3d11_images.size()) {
+            source_image_index(it->second) >= it->second.d3d11_images.size() ||
+            source_layer->views[i].subImage.imageArrayIndex >= std::max<uint32_t>(1, it->second.array_size)) {
             return false;
         }
         swapchains[i] = &it->second;
@@ -2792,17 +2964,32 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
     } saved;
 
     ID3D11DeviceContext* context = d3d11_quadviews_compositor_.context;
-    context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, &saved.depth_stencil);
-    context->VSGetShader(&saved.vertex_shader, nullptr, nullptr);
-    context->PSGetShader(&saved.pixel_shader, nullptr, nullptr);
-    context->IAGetInputLayout(&saved.input_layout);
-    context->IAGetPrimitiveTopology(&saved.topology);
-    context->PSGetShaderResources(0, 2, saved.shader_resources);
-    context->PSGetSamplers(0, 1, saved.samplers);
-    context->PSGetConstantBuffers(0, 1, saved.constant_buffers);
-    context->RSGetViewports(&saved.viewport_count, saved.viewports);
+    ID3DDeviceContextState* application_context_state = nullptr;
+    const bool use_context_state = d3d11_quadviews_compositor_.context1 &&
+                                   d3d11_quadviews_compositor_.layer_context_state;
+    if (use_context_state) {
+        d3d11_quadviews_compositor_.context1->SwapDeviceContextState(
+            d3d11_quadviews_compositor_.layer_context_state, &application_context_state);
+        context->ClearState();
+    } else {
+        context->OMGetRenderTargets(
+            D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, &saved.depth_stencil);
+        context->VSGetShader(&saved.vertex_shader, nullptr, nullptr);
+        context->PSGetShader(&saved.pixel_shader, nullptr, nullptr);
+        context->IAGetInputLayout(&saved.input_layout);
+        context->IAGetPrimitiveTopology(&saved.topology);
+        context->PSGetShaderResources(0, 2, saved.shader_resources);
+        context->PSGetSamplers(0, 1, saved.samplers);
+        context->PSGetConstantBuffers(0, 1, saved.constant_buffers);
+        context->RSGetViewports(&saved.viewport_count, saved.viewports);
+    }
 
     auto restore_state = [&]() {
+        if (use_context_state) {
+            d3d11_quadviews_compositor_.context1->SwapDeviceContextState(application_context_state, nullptr);
+            SafeRelease(application_context_state);
+            return;
+        }
         context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, saved.depth_stencil);
         context->VSSetShader(saved.vertex_shader, nullptr, 0);
         context->PSSetShader(saved.pixel_shader, nullptr, 0);
@@ -2953,7 +3140,7 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
             break;
         }
         XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
-        wait_info.timeout = XR_INFINITE_DURATION;
+        wait_info.timeout = kInternalSwapchainWaitTimeout;
         result = next_wait_swapchain_image_(target.swapchain, &wait_info);
         if (XR_FAILED(result)) {
             failure_reason = "outputWait eye=" + std::to_string(eye) +
@@ -2977,9 +3164,15 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         ID3D11ShaderResourceView* focus_resource = nullptr;
         SwapchainInfo& peripheral_swapchain = *swapchains[eye];
         SwapchainInfo& focus_swapchain = *swapchains[eye + 2];
-        if (EnsureD3D11SwapchainShaderResources(peripheral_swapchain) &&
-            peripheral_index < peripheral_swapchain.d3d11_shader_resources.size()) {
-            peripheral_resource = peripheral_swapchain.d3d11_shader_resources[peripheral_index];
+        const uint32_t peripheral_slice = source_layer->views[eye].subImage.imageArrayIndex;
+        const uint32_t focus_slice = source_layer->views[eye + 2].subImage.imageArrayIndex;
+        const size_t peripheral_slot =
+            peripheral_index * std::max<uint32_t>(1, peripheral_swapchain.array_size) + peripheral_slice;
+        const size_t focus_slot =
+            focus_index * std::max<uint32_t>(1, focus_swapchain.array_size) + focus_slice;
+        if (EnsureD3D11SwapchainShaderResources(peripheral_swapchain, peripheral_slice) &&
+            peripheral_slot < peripheral_swapchain.d3d11_shader_resources.size()) {
+            peripheral_resource = peripheral_swapchain.d3d11_shader_resources[peripheral_slot];
             ++direct_input_count;
         } else {
             if (!ensure_input_copy(eye, *swapchains[eye])) {
@@ -2987,13 +3180,22 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                 rendered = false;
                 break;
             }
-            context->CopyResource(d3d11_quadviews_compositor_.input_copies[eye].texture, peripheral_source);
+            const UINT source_subresource =
+                D3D11CalcSubresource(0, peripheral_slice, std::max<uint32_t>(1, peripheral_swapchain.mip_count));
+            context->CopySubresourceRegion(d3d11_quadviews_compositor_.input_copies[eye].texture,
+                                           0,
+                                           0,
+                                           0,
+                                           0,
+                                           peripheral_source,
+                                           source_subresource,
+                                           nullptr);
             peripheral_resource = d3d11_quadviews_compositor_.input_copies[eye].shader_resource;
             ++input_copy_count;
         }
-        if (EnsureD3D11SwapchainShaderResources(focus_swapchain) &&
-            focus_index < focus_swapchain.d3d11_shader_resources.size()) {
-            focus_resource = focus_swapchain.d3d11_shader_resources[focus_index];
+        if (EnsureD3D11SwapchainShaderResources(focus_swapchain, focus_slice) &&
+            focus_slot < focus_swapchain.d3d11_shader_resources.size()) {
+            focus_resource = focus_swapchain.d3d11_shader_resources[focus_slot];
             ++direct_input_count;
         } else {
             if (!ensure_input_copy(eye + 2, *swapchains[eye + 2])) {
@@ -3001,7 +3203,16 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                 rendered = false;
                 break;
             }
-            context->CopyResource(d3d11_quadviews_compositor_.input_copies[eye + 2].texture, focus_source);
+            const UINT source_subresource =
+                D3D11CalcSubresource(0, focus_slice, std::max<uint32_t>(1, focus_swapchain.mip_count));
+            context->CopySubresourceRegion(d3d11_quadviews_compositor_.input_copies[eye + 2].texture,
+                                           0,
+                                           0,
+                                           0,
+                                           0,
+                                           focus_source,
+                                           source_subresource,
+                                           nullptr);
             focus_resource = d3d11_quadviews_compositor_.input_copies[eye + 2].shader_resource;
             ++input_copy_count;
         }
@@ -3049,14 +3260,32 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
 
         const XrFovf& full_fov = has_cached_fovs ? cached_fovs[eye] : source_layer->views[eye].fov;
         const XrFovf& focus_fov = has_cached_fovs ? cached_fovs[eye + 2] : source_layer->views[eye + 2].fov;
+        const XrSwapchainSubImage& peripheral_sub_image = source_layer->views[eye].subImage;
+        const XrSwapchainSubImage& focus_sub_image = source_layer->views[eye + 2].subImage;
+        const uint32_t focus_content_width =
+            static_cast<uint32_t>(std::max<int32_t>(1, focus_sub_image.imageRect.extent.width));
+        const uint32_t focus_content_height =
+            static_cast<uint32_t>(std::max<int32_t>(1, focus_sub_image.imageRect.extent.height));
         FocusRectConstants constants = BuildFocusRectConstants(full_fov,
                                                                focus_fov,
                                                                target.width,
                                                                target.height,
-                                                               focus_swapchain.width,
-                                                               focus_swapchain.height,
+                                                               focus_content_width,
+                                                               focus_content_height,
                                                                resolved_settings_.quadviews.transition_thickness_percent,
                                                                resolved_settings_.quadviews.foveate_sharpness);
+        const auto set_source_rect = [](float (&destination)[4],
+                                        const XrSwapchainSubImage& sub_image,
+                                        const SwapchainInfo& swapchain) {
+            const float width = static_cast<float>(std::max<uint32_t>(1, swapchain.width));
+            const float height = static_cast<float>(std::max<uint32_t>(1, swapchain.height));
+            destination[0] = static_cast<float>(sub_image.imageRect.offset.x) / width;
+            destination[1] = static_cast<float>(sub_image.imageRect.offset.y) / height;
+            destination[2] = static_cast<float>(sub_image.imageRect.extent.width) / width;
+            destination[3] = static_cast<float>(sub_image.imageRect.extent.height) / height;
+        };
+        set_source_rect(constants.peripheral_src_rect, peripheral_sub_image, peripheral_swapchain);
+        set_source_rect(constants.focus_src_rect, focus_sub_image, focus_swapchain);
         if (should_log_compositor_diagnostic) {
             // Effective focus sampling ratio: focus texture pixels vs. the output pixels its
             // sub-rectangle occupies. ~1.0 = ideal 1:1; >1.0 = focus is being downsampled
@@ -3065,8 +3294,8 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                 std::max(1.0, static_cast<double>(constants.focus_rect[2] - constants.focus_rect[0]) * target.width);
             const double focus_rect_output_height =
                 std::max(1.0, static_cast<double>(constants.focus_rect[3] - constants.focus_rect[1]) * target.height);
-            const double focus_sampling_ratio_x = focus_swapchain.width / focus_rect_output_width;
-            const double focus_sampling_ratio_y = focus_swapchain.height / focus_rect_output_height;
+            const double focus_sampling_ratio_x = focus_content_width / focus_rect_output_width;
+            const double focus_sampling_ratio_y = focus_content_height / focus_rect_output_height;
             std::ostringstream stream;
             stream << "D3D11 quadviews compositor focus rect: frameTime=" << display_time
                    << ", eye=" << eye
@@ -3077,7 +3306,7 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
                    << FormatDiagnosticDouble(constants.focus_rect[1]) << ", "
                    << FormatDiagnosticDouble(constants.focus_rect[2]) << ", "
                    << FormatDiagnosticDouble(constants.focus_rect[3]) << ")"
-                   << ", focusTex=" << focus_swapchain.width << "x" << focus_swapchain.height
+                   << ", focusTex=" << focus_content_width << "x" << focus_content_height
                    << ", focusRectOutputPx=" << FormatDiagnosticDouble(focus_rect_output_width) << "x"
                    << FormatDiagnosticDouble(focus_rect_output_height)
                    << ", focusSamplingRatio=(" << FormatDiagnosticDouble(focus_sampling_ratio_x) << ", "
@@ -3285,15 +3514,27 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
                 }
             }
             if (wait_pipelined) {
+                bool mark_wait_polled = true;
                 if (turbo_async_wait_polled_) {
                     // Second poll while pipelined: only one frame of
                     // pipelining is allowed, so now we must wait for the real
-                    // frame.
+                    // frame. Keep a shared snapshot: EndFrame may retire the
+                    // member while this app thread is blocked.
+                    const std::shared_future<void> pending_wait = turbo_async_wait_;
+                    const std::uint64_t pending_generation = turbo_async_wait_generation_;
                     lock.unlock();
-                    turbo_async_wait_.wait();
+                    pending_wait.wait();
                     lock.lock();
+                    if (pending_generation != turbo_async_wait_generation_) {
+                        // EndFrame already retired this wait and may have
+                        // launched the following one. Do not mark that newer
+                        // wait as having been polled by this older call.
+                        mark_wait_polled = false;
+                    }
                 }
-                turbo_async_wait_polled_ = true;
+                if (mark_wait_polled) {
+                    turbo_async_wait_polled_ = true;
+                }
             }
 
             const auto now = std::chrono::steady_clock::now();
@@ -3449,6 +3690,10 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
     // exactly this on SteamVR, silently, after one rendered frame). The
     // first observation is skipped — apps commonly start empty while loading.
     const bool submitting_layers = frame_end_info && frame_end_info->layerCount > 0;
+    if (frame_end_info) {
+        std::scoped_lock lock(turbo_mutex_);
+        turbo_last_environment_blend_mode_ = frame_end_info->environmentBlendMode;
+    }
     if (!app_submitting_layers_.has_value()) {
         app_submitting_layers_ = submitting_layers;
     } else if (*app_submitting_layers_ != submitting_layers) {
@@ -3569,10 +3814,16 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
     bool frame_begun = false;
     bool begin_owed = false;
     bool valve_open = false;
+    std::shared_future<void> pending_async_wait;
+    std::uint64_t pending_async_generation = 0;
     TurboSequencedState seq_state = TurboSequencedState::kInactive;
     {
         std::scoped_lock lock(turbo_mutex_);
         has_pending_wait = turbo_async_wait_.valid();
+        if (has_pending_wait) {
+            pending_async_wait = turbo_async_wait_;
+            pending_async_generation = turbo_async_wait_generation_;
+        }
         // This submit consumes the begun-frame marker (set by our pre-begin,
         // a compensation begin, or the app's own begin passing through).
         frame_begun = turbo_frame_begun_;
@@ -3586,6 +3837,11 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
         // End(N) — the MSFS2024 ordering).
         turbo_end_frame_in_flight_ = true;
     }
+    const auto abandon_end_frame_window = [this] {
+        std::scoped_lock lock(turbo_mutex_);
+        turbo_end_frame_in_flight_ = false;
+        turbo_begin_deferred_ = false;
+    };
     if (TurboSequencedDebugTick()) {
         logger_.Debug("Turbo-diag: pre-submit snapshot: engaged=" + std::to_string(turbo_engaged ? 1 : 0) +
                       ", seqState=" + std::to_string(static_cast<int>(seq_state)) +
@@ -3609,7 +3865,8 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             logger_.Debug("Turbo-diag: async drain starting (250ms cap).");
         }
         const auto drain_start = std::chrono::steady_clock::now();
-        const bool ready = turbo_async_wait_.wait_for(kTurboDrainTimeout) == std::future_status::ready;
+        const bool ready =
+            pending_async_wait.wait_for(kTurboDrainTimeout) == std::future_status::ready;
         const double drain_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - drain_start)
                 .count();
@@ -3618,11 +3875,17 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             logger_.Debug("Turbo-diag: async drain completed in " + std::to_string(drain_ms) +
                           "ms, ready=" + std::to_string(ready ? 1 : 0));
         }
+        XrResult async_wait_result = XR_SUCCESS;
         {
             std::scoped_lock lock(turbo_mutex_);
-            if (ready) {
+            if (ready && pending_async_generation == turbo_async_wait_generation_) {
+                async_wait_result = turbo_async_wait_result_;
                 turbo_async_wait_ = {};
             }
+        }
+        if (ready && XR_FAILED(async_wait_result)) {
+            abandon_end_frame_window();
+            return async_wait_result;
         }
         // Only count while engaged with a healthy cadence: a drain-out during
         // a suspend, or a stall while the app itself is hitching/loading, is
@@ -3645,6 +3908,7 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             if (XR_FAILED(begin_result)) {
                 logger_.Error("Turbo: deferred xrBeginFrame failed with " +
                               std::to_string(static_cast<int>(begin_result)));
+                abandon_end_frame_window();
                 return begin_result;
             }
         }
@@ -3693,6 +3957,7 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             if (XR_FAILED(begin_result)) {
                 logger_.Error("Turbo: compensation xrBeginFrame failed with " +
                               std::to_string(static_cast<int>(begin_result)));
+                abandon_end_frame_window();
                 return begin_result;
             }
         } else {
@@ -3865,26 +4130,14 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                 }
                 turbo_async_wait_polled_ = false;
                 turbo_async_wait_completed_ = false;
-                turbo_async_wait_ = std::async(std::launch::async, [this, session] {
-                    XrFrameState frame_state{XR_TYPE_FRAME_STATE};
-                    XrResult wait_result = XR_SUCCESS;
-                    {
-                        std::scoped_lock wait_lock(turbo_runtime_wait_mutex_);
-                        wait_result = next_wait_frame_(session, nullptr, &frame_state);
-                    }
-                    std::scoped_lock state_lock(turbo_mutex_);
-                    if (XR_SUCCEEDED(wait_result)) {
-                        turbo_last_predicted_display_time_ = frame_state.predictedDisplayTime;
-                        turbo_last_predicted_display_period_ = frame_state.predictedDisplayPeriod;
-                        turbo_last_should_render_ = frame_state.shouldRender == XR_TRUE;
-                        NoteTurboShouldRenderLocked(turbo_last_should_render_);
-                    } else {
-                        logger_.Error("Turbo: async xrWaitFrame failed with " +
-                                      std::to_string(static_cast<int>(wait_result)) +
-                                      "; keeping previous frame timing.");
-                    }
-                    turbo_async_wait_completed_ = true;
-                });
+                turbo_async_wait_result_ = XR_SUCCESS;
+                ++turbo_async_wait_generation_;
+                EnsureTurboAsyncWorkerLocked();
+                turbo_async_job_completion_ = std::make_shared<std::promise<void>>();
+                turbo_async_wait_ = turbo_async_job_completion_->get_future().share();
+                turbo_async_job_session_ = session;
+                turbo_async_job_pending_ = true;
+                turbo_async_worker_cv_.notify_one();
             }
         }
 
@@ -4026,8 +4279,11 @@ void OpenXrLayer::ResolveTurboPacingModeLocked() {
         }
     }
 
-    if (const auto observation =
-            FindRuntimePacingObservation(ResolveRuntimePacingPath(), runtime_name_)) {
+    if (const auto observation = FindRuntimePacingObservation(ResolveRuntimePacingPath(),
+                                                              runtime_name_,
+                                                              system_name_,
+                                                              system_vendor_id_,
+                                                              graphics_api_)) {
         if (observation->mode == TurboPacingMode::kUnsupported) {
             // Verdict from a previous session: even sequenced pacing stalled.
             // Suspend before the first pipelined frame instead of replaying
@@ -4049,15 +4305,18 @@ void OpenXrLayer::ResolveTurboPacingModeLocked() {
                      observation->source + ").");
         RuntimePacingObservation updated = *observation;
         updated.runtime_version = runtime_version_;
+        updated.system_name = system_name_;
+        updated.vendor_id = system_vendor_id_;
+        updated.graphics_api = graphics_api_;
         updated.last_used_unix_seconds =
             std::chrono::duration_cast<std::chrono::seconds>(
                 std::chrono::system_clock::now().time_since_epoch())
                 .count();
-        RecordRuntimePacingObservation(ResolveRuntimePacingPath(), updated, nullptr);
+        QueueRuntimePacingWrite(std::move(updated));
         return;
     }
 
-    if (const auto seeded = SeededTurboPacingMode(runtime_name_)) {
+    if (const auto seeded = SeededTurboPacingMode(runtime_name_, system_name_)) {
         turbo_pacing_mode_ = *seeded;
         turbo_pacing_source_ = TurboPacingSource::kPreset;
         turbo_pacing_verdict_pending_ = true;
@@ -4083,6 +4342,9 @@ void OpenXrLayer::RecordTurboPacingVerdict(TurboPacingMode mode,
     RuntimePacingObservation observation;
     observation.runtime_name = runtime_name_;
     observation.runtime_version = runtime_version_;
+    observation.system_name = system_name_;
+    observation.vendor_id = system_vendor_id_;
+    observation.graphics_api = graphics_api_;
     observation.mode = mode;
     observation.source = source;
 #if defined(VECTORXR_VERSION)
@@ -4095,12 +4357,42 @@ void OpenXrLayer::RecordTurboPacingVerdict(TurboPacingMode mode,
     observation.probe_timeouts = turbo_probe_timeout_total_;
     observation.stable_seconds = stable_seconds;
 
-    std::string error;
-    if (RecordRuntimePacingObservation(ResolveRuntimePacingPath(), observation, &error)) {
-        logger_.Info(std::string("Turbo pacing: recorded ") + ToString(mode) +
-                     " verdict for runtime \"" + runtime_name_ + "\" (" + source + ").");
-    } else {
-        logger_.Info("Turbo pacing: failed to record verdict: " + error);
+    QueueRuntimePacingWrite(std::move(observation));
+    logger_.Info(std::string("Turbo pacing: queued ") + ToString(mode) +
+                 " verdict for runtime \"" + runtime_name_ + "\" (" + source + ").");
+}
+
+void OpenXrLayer::QueueRuntimePacingWrite(RuntimePacingObservation observation) {
+    if (runtime_pacing_write_future_.valid()) {
+        if (runtime_pacing_write_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+            pending_runtime_pacing_write_ = std::move(observation);
+            return;
+        }
+        runtime_pacing_write_future_.get();
+        runtime_pacing_write_future_ = {};
+    }
+
+    runtime_pacing_write_future_ =
+        std::async(std::launch::async, [this, path = ResolveRuntimePacingPath(), observation = std::move(observation)] {
+            std::string error;
+            if (!RecordRuntimePacingObservation(path, observation, &error)) {
+                logger_.Info("Turbo pacing: background verdict write failed: " + error);
+            }
+        });
+}
+
+void OpenXrLayer::DrainRuntimePacingWrites() {
+    if (runtime_pacing_write_future_.valid()) {
+        runtime_pacing_write_future_.wait();
+        runtime_pacing_write_future_ = {};
+    }
+    if (pending_runtime_pacing_write_.has_value()) {
+        RuntimePacingObservation pending = std::move(*pending_runtime_pacing_write_);
+        pending_runtime_pacing_write_.reset();
+        std::string error;
+        if (!RecordRuntimePacingObservation(ResolveRuntimePacingPath(), pending, &error)) {
+            logger_.Info("Turbo pacing: final verdict write failed: " + error);
+        }
     }
 }
 
@@ -4512,14 +4804,90 @@ void OpenXrLayer::ResetTurboMetricsState() {
     turbo_metrics_fabricated_pending_ = 0;
 }
 
+void OpenXrLayer::EnsureTurboAsyncWorkerLocked() {
+    if (turbo_async_worker_.joinable()) {
+        return;
+    }
+    turbo_async_worker_stop_ = false;
+    turbo_async_worker_ = std::thread([this] { TurboAsyncWorkerLoop(); });
+}
+
+void OpenXrLayer::TurboAsyncWorkerLoop() {
+    for (;;) {
+        XrSession session = XR_NULL_HANDLE;
+        std::shared_ptr<std::promise<void>> completion;
+        {
+            std::unique_lock lock(turbo_mutex_);
+            turbo_async_worker_cv_.wait(lock, [this] {
+                return turbo_async_worker_stop_ || turbo_async_job_pending_;
+            });
+            if (turbo_async_worker_stop_) {
+                return;
+            }
+            session = turbo_async_job_session_;
+            completion = std::move(turbo_async_job_completion_);
+            turbo_async_job_pending_ = false;
+        }
+
+        XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+        XrResult wait_result = XR_SUCCESS;
+        {
+            std::scoped_lock wait_lock(turbo_runtime_wait_mutex_);
+            wait_result = next_wait_frame_(session, nullptr, &frame_state);
+        }
+        {
+            std::scoped_lock state_lock(turbo_mutex_);
+            if (XR_SUCCEEDED(wait_result)) {
+                turbo_last_predicted_display_time_ = frame_state.predictedDisplayTime;
+                turbo_last_predicted_display_period_ = frame_state.predictedDisplayPeriod;
+                turbo_last_should_render_ = frame_state.shouldRender == XR_TRUE;
+                NoteTurboShouldRenderLocked(turbo_last_should_render_);
+            } else {
+                logger_.Error("Turbo: async xrWaitFrame failed with " +
+                              std::to_string(static_cast<int>(wait_result)) +
+                              "; keeping previous frame timing.");
+            }
+            turbo_async_wait_result_ = wait_result;
+            turbo_async_wait_completed_ = true;
+        }
+        if (completion) {
+            completion->set_value();
+        }
+    }
+}
+
+void OpenXrLayer::StopTurboAsyncWorker() {
+    DrainTurboAsyncWait();
+    {
+        std::scoped_lock lock(turbo_mutex_);
+        turbo_async_worker_stop_ = true;
+        turbo_async_worker_cv_.notify_all();
+    }
+    if (turbo_async_worker_.joinable()) {
+        turbo_async_worker_.join();
+    }
+    {
+        std::scoped_lock lock(turbo_mutex_);
+        turbo_async_worker_stop_ = false;
+        turbo_async_job_pending_ = false;
+        turbo_async_job_session_ = XR_NULL_HANDLE;
+        turbo_async_job_completion_.reset();
+    }
+}
+
 void OpenXrLayer::DrainTurboAsyncWait() {
     // Wait without consuming the future: the pipelined frame is still pending
     // and will be begun/ended by the normal path — only the blocking runtime
     // call must finish before teardown proceeds.
-    std::unique_lock lock(turbo_mutex_);
-    if (turbo_async_wait_.valid()) {
-        lock.unlock();
-        turbo_async_wait_.wait();
+    std::shared_future<void> pending_wait;
+    {
+        std::scoped_lock lock(turbo_mutex_);
+        if (turbo_async_wait_.valid()) {
+            pending_wait = turbo_async_wait_;
+        }
+    }
+    if (pending_wait.valid()) {
+        pending_wait.wait();
     }
 }
 
@@ -4527,20 +4895,26 @@ void OpenXrLayer::ResetTurboFrameState() {
     // Final metrics flush first (it takes turbo_mutex_ itself and joins the
     // async writer); a second call at teardown is a no-op.
     ResetTurboMetricsState();
+    DrainRuntimePacingWrites();
+    // The async wait worker publishes its result while taking turbo_mutex_.
+    // Join it before taking that mutex ourselves; destroying the last async
+    // shared state under the lock would otherwise deadlock teardown.
+    DrainTurboAsyncWait();
     end_frame_error_log_budget_ = 5;
     submission_transition_log_budget_ = 8;
     app_submitting_layers_.reset();
     std::scoped_lock lock(turbo_mutex_);
     should_render_log_budget_ = 8;
     last_noted_should_render_.reset();
-    // Destroying a std::async future joins its thread, which is the drain we
-    // want at session teardown.
     turbo_async_wait_ = {};
+    ++turbo_async_wait_generation_;
     turbo_async_wait_polled_ = false;
     turbo_async_wait_completed_ = false;
+    turbo_async_wait_result_ = XR_SUCCESS;
     turbo_last_predicted_display_time_ = 0;
     turbo_last_predicted_display_period_ = 0;
     turbo_last_should_render_ = true;
+    turbo_last_environment_blend_mode_ = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
     turbo_max_returned_display_time_ = 0;
     turbo_last_wait_frame_wall_time_.reset();
     turbo_pipelining_logged_ = false;
@@ -4604,7 +4978,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     }
 
     const bool quadviews_projection_split_active =
-        IsQuadViewsActive() && has_active_primary_view_configuration_ &&
+        IsQuadViewsEmulationActive() && has_active_primary_view_configuration_ &&
         IsQuadViewConfiguration(active_primary_view_configuration_type_) &&
         active_runtime_view_configuration_type_ == XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     // Varjo compatible quadviews: the focus sharpen runs inside the projection
@@ -4862,8 +5236,7 @@ XrResult OpenXrLayer::GetReferenceSpaceBoundsRect(XrSession session,
             RefreshResolvedSettings();
             // In Varjo compatible mode the runtime provides the real combined-eye space,
             // so only emulate it while synthesizing quad views.
-            emulate_combined_eye =
-                session == active_session_ && IsQuadViewsActive() && !varjo_compatible_quadviews_active_;
+            emulate_combined_eye = session == active_session_ && IsQuadViewsEmulationActive();
         }
 
         if (emulate_combined_eye) {
@@ -4914,7 +5287,7 @@ XrResult OpenXrLayer::EnumerateReferenceSpaces(XrSession session,
     RefreshResolvedSettings();
 
     std::vector<XrReferenceSpaceType> exposed_spaces = runtime_spaces;
-    if (session == active_session_ && IsQuadViewsActive() &&
+    if (session == active_session_ && IsQuadViewsEmulationActive() &&
         std::find(exposed_spaces.begin(),
                   exposed_spaces.end(),
                   XR_REFERENCE_SPACE_TYPE_COMBINED_EYE_VARJO) == exposed_spaces.end()) {
@@ -4947,8 +5320,7 @@ XrResult OpenXrLayer::CreateReferenceSpace(XrSession session,
             RefreshResolvedSettings();
             // In Varjo compatible mode the runtime provides the real combined-eye space,
             // so only emulate it while synthesizing quad views.
-            emulate_combined_eye =
-                session == active_session_ && IsQuadViewsActive() && !varjo_compatible_quadviews_active_;
+            emulate_combined_eye = session == active_session_ && IsQuadViewsEmulationActive();
         }
 
         if (emulate_combined_eye) {
@@ -5175,30 +5547,45 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
         double applied_extra_yaw_radians = 0.0;
         double applied_extra_pitch_radians = 0.0;
         XrPosef applied_pose_delta = IdentityPose();
-        const XrResult pivot_result = LocateSpaceWithPivot(internal_view_space_,
-                                                           view_locate_info->space,
-                                                           internal_locate_time,
-                                                           pivotxr_active,
-                                                           &pivot_view_location,
-                                                           &applied_extra_yaw_radians,
-                                                           &applied_extra_pitch_radians,
-                                                           &applied_pose_delta,
-                                                           true);
+        XrPosef runtime_view_pose = IdentityPose();
+        XrResult pivot_result = next_locate_space_(
+            internal_view_space_, view_locate_info->space, internal_locate_time, &pivot_view_location);
         if (XR_SUCCEEDED(pivot_result)) {
+            runtime_view_pose = pivot_view_location.pose;
+            pivot_result = ApplyPivotToLocatedSpace(internal_view_space_,
+                                                     view_locate_info->space,
+                                                     internal_locate_time,
+                                                     pivotxr_active,
+                                                     &pivot_view_location,
+                                                     &applied_extra_yaw_radians,
+                                                     &applied_extra_pitch_radians,
+                                                     &applied_pose_delta,
+                                                     true);
+        }
+        if (XR_SUCCEEDED(pivot_result)) {
+            const auto ensure_eye_offsets = [&](XrViewConfigurationType offset_view_configuration,
+                                                uint32_t offset_count) {
+                constexpr XrSpaceLocationFlags kPoseValid =
+                    XR_SPACE_LOCATION_ORIENTATION_VALID_BIT | XR_SPACE_LOCATION_POSITION_VALID_BIT;
+                const bool derived =
+                    (pivot_view_location.locationFlags & kPoseValid) == kPoseValid && views && count >= offset_count &&
+                    CacheEyeOffsetsFromLocatedViews(offset_view_configuration,
+                                                    internal_locate_time,
+                                                    runtime_view_pose,
+                                                    std::span<const XrView>(views, count),
+                                                    offset_count);
+                return derived || EnsureEyeOffsets(
+                                      session, offset_view_configuration, internal_locate_time, offset_count);
+            };
             if (NearlyZero(applied_extra_yaw_radians) && NearlyZero(applied_extra_pitch_radians)) {
                 pivot_diagnostic_.recomposition_mode = "identity";
                 pivot_diagnostic_.has_eye_offsets = false;
                 CachePivotPoseDelta(view_locate_info->displayTime, IdentityPose());
             } else if (IsQuadViewConfiguration(view_configuration_type) &&
-                       EnsureEyeOffsets(session,
-                                        // Emulation synthesizes quad from stereo, so it captures 2 stereo eye
-                                        // offsets. Varjo compatible mode locates the real quad config (same config as
-                                        // the session) to get one offset per view and avoid a cross-config locate.
-                                        varjo_compatible_quadviews_active_
-                                            ? view_configuration_type
-                                            : XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO,
-                                        internal_locate_time,
-                                        varjo_compatible_quadviews_active_ ? count : 2)) {
+                       ensure_eye_offsets(varjo_compatible_quadviews_active_
+                                              ? view_configuration_type
+                                              : XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO,
+                                          varjo_compatible_quadviews_active_ ? count : 2)) {
                 pivot_diagnostic_.recomposition_mode =
                     varjo_compatible_quadviews_active_ ? "quad_native_eye_offsets" : "quad_from_stereo_eye_offsets";
                 CachePivotPoseDelta(view_locate_info->displayTime, applied_pose_delta);
@@ -5217,7 +5604,7 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                     adjusted_views[i].orientation.w = recomposed_pose.orientation.w;
                 }
             } else if (!IsQuadViewConfiguration(view_configuration_type) &&
-                       EnsureEyeOffsets(session, view_configuration_type, internal_locate_time, count)) {
+                       ensure_eye_offsets(view_configuration_type, count)) {
                 pivot_diagnostic_.recomposition_mode = "stereo_eye_offsets";
                 CachePivotPoseDelta(view_locate_info->displayTime, applied_pose_delta);
                 for (uint32_t i = 0; i < count; ++i) {
@@ -5669,14 +6056,16 @@ void OpenXrLayer::RefreshResolvedSettings() {
         ResetQuadViewsDebugHeartbeatState();
     }
 
-    if (IsQuadViewsActive() && resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye &&
+    if (IsQuadViewsEmulationActive() &&
+        resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye &&
         active_session_ != XR_NULL_HANDLE && !eye_gaze_resources_ready_) {
         const XrResult eye_gaze_result = CreateEyeGazeResources(active_session_);
         if (XR_FAILED(eye_gaze_result)) {
             logger_.Info("Eye gaze resources unavailable after quadviews tracking-mode change; head/static focus remains active.");
             DestroyEyeGazeResources();
         }
-    } else if ((!IsQuadViewsActive() || resolved_settings_.quadviews.tracking_mode != QuadViewsTrackingMode::Eye) &&
+    } else if ((!IsQuadViewsEmulationActive() ||
+                resolved_settings_.quadviews.tracking_mode != QuadViewsTrackingMode::Eye) &&
                eye_gaze_resources_ready_) {
         DestroyEyeGazeResources();
     }
@@ -5708,6 +6097,11 @@ void OpenXrLayer::CaptureInstanceFunctions() {
     function = nullptr;
     if (XR_SUCCEEDED(next_get_instance_proc_addr_(instance_, "xrBeginSession", &function))) {
         next_begin_session_ = reinterpret_cast<PFN_xrBeginSession>(function);
+    }
+
+    function = nullptr;
+    if (XR_SUCCEEDED(next_get_instance_proc_addr_(instance_, "xrEndSession", &function))) {
+        next_end_session_ = reinterpret_cast<PFN_xrEndSession>(function);
     }
 
     function = nullptr;
@@ -5921,6 +6315,7 @@ void OpenXrLayer::ResetSessionState() {
     quadviews_smoothed_focus_yaw_radians_ = 0.0;
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
+    quadviews_last_valid_gaze_wall_time_.reset();
     active_primary_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     active_runtime_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     has_active_primary_view_configuration_ = false;
@@ -5935,16 +6330,21 @@ void OpenXrLayer::ResetSessionState() {
     cached_pivot_pose_deltas_.clear();
     cached_quadviews_fovs_.clear();
     last_app_action_sync_time_.reset();
+    last_eye_gaze_self_sync_time_.reset();
     ResetSwapchainState();
 }
 
 void OpenXrLayer::ResetInstanceState() {
     quad_views_extension_requested_ = false;
     varjo_foveated_rendering_extension_requested_ = false;
+    d3d11_graphics_extension_requested_ = false;
     eye_gaze_extension_enabled_ = false;
     defer_quadviews_swapchain_releases_ = false;
     runtime_name_.clear();
     runtime_version_.clear();
+    system_name_.clear();
+    system_vendor_id_ = 0;
+    graphics_api_.clear();
     turbo_pacing_resolved_ = false;
     cached_quadviews_stereo_recommended_width_ = 0;
     cached_quadviews_stereo_recommended_height_ = 0;
@@ -5955,6 +6355,11 @@ void OpenXrLayer::ResetInstanceState() {
 
 bool OpenXrLayer::IsQuadViewsActive() const {
     return resolved_settings_.core.enabled && resolved_settings_.quadviews.enabled;
+}
+
+bool OpenXrLayer::IsQuadViewsEmulationActive() const {
+    return IsQuadViewsActive() && !varjo_compatible_quadviews_active_ &&
+           d3d11_graphics_extension_requested_;
 }
 
 bool OpenXrLayer::IsVarjoCompatibleQuadviewsEligible() {
@@ -6096,6 +6501,8 @@ void OpenXrLayer::DestroyEyeGazeResources() {
     quadviews_smoothed_focus_yaw_radians_ = 0.0;
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
+    quadviews_last_valid_gaze_wall_time_.reset();
+    last_eye_gaze_self_sync_time_.reset();
 
     if (eye_gaze_space != XR_NULL_HANDLE && next_destroy_space_) {
         next_destroy_space_(eye_gaze_space);
@@ -6212,7 +6619,9 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
     const auto sync_check_now = std::chrono::steady_clock::now();
     const bool app_sync_fresh = last_app_action_sync_time_.has_value() &&
                                 sync_check_now - *last_app_action_sync_time_ < kAppActionSyncFreshWindow;
-    if (!app_sync_fresh) {
+    const bool self_sync_fresh = last_eye_gaze_self_sync_time_.has_value() &&
+                                 sync_check_now - *last_eye_gaze_self_sync_time_ < kAppActionSyncFreshWindow;
+    if (!app_sync_fresh && !self_sync_fresh) {
         const XrActiveActionSet active_action_set{quadviews_action_set_, XR_NULL_PATH};
         XrActionsSyncInfo sync_info{XR_TYPE_ACTIONS_SYNC_INFO};
         sync_info.countActiveActionSets = 1;
@@ -6222,6 +6631,7 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
             log_eye_gaze_diagnostic("self sync failed, result=" + FormatHex(static_cast<uint64_t>(sync_result)));
             return false;
         }
+        last_eye_gaze_self_sync_time_ = sync_check_now;
     }
 
     XrActionStateGetInfo action_state_info{XR_TYPE_ACTION_STATE_GET_INFO};
@@ -6275,6 +6685,7 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
     }
 
     const auto now = std::chrono::steady_clock::now();
+    quadviews_last_valid_gaze_wall_time_ = now;
     double delta_seconds = 0.0;
     if (quadviews_last_focus_smoothing_wall_time_.has_value()) {
         delta_seconds = std::chrono::duration<double>(now - *quadviews_last_focus_smoothing_wall_time_).count();
@@ -6408,6 +6819,34 @@ void OpenXrLayer::DestroyInternalReferenceSpaces() {
     cached_quadviews_fovs_.clear();
 }
 
+bool OpenXrLayer::CacheEyeOffsetsFromLocatedViews(XrViewConfigurationType view_configuration_type,
+                                                   XrTime display_time,
+                                                   const XrPosef& runtime_view_pose,
+                                                   std::span<const XrView> located_views,
+                                                   uint32_t view_count) {
+    if (view_count == 0 || located_views.size() < view_count) {
+        return false;
+    }
+
+    const XrPosef inverse_view_pose = InvertPose(runtime_view_pose);
+    cached_eye_offset_poses_.resize(view_count);
+    for (uint32_t i = 0; i < view_count; ++i) {
+        cached_eye_offset_poses_[i] = MultiplyPoses(located_views[i].pose, inverse_view_pose);
+    }
+    cached_eye_offsets_view_configuration_ = view_configuration_type;
+    cached_eye_offsets_display_time_ = display_time;
+
+    pivot_diagnostic_.has_eye_offsets = true;
+    pivot_diagnostic_.eye_offsets_time = display_time;
+    pivot_diagnostic_.eye_offsets_view_configuration = view_configuration_type;
+    pivot_diagnostic_.eye_offset_count =
+        std::min<uint32_t>(view_count, static_cast<uint32_t>(pivot_diagnostic_.eye_offsets.size()));
+    for (uint32_t i = 0; i < pivot_diagnostic_.eye_offset_count; ++i) {
+        pivot_diagnostic_.eye_offsets[i] = cached_eye_offset_poses_[i];
+    }
+    return true;
+}
+
 bool OpenXrLayer::EnsureEyeOffsets(XrSession session,
                                    XrViewConfigurationType view_configuration_type,
                                    XrTime display_time,
@@ -6468,6 +6907,9 @@ bool OpenXrLayer::EnsureEyeOffsets(XrSession session,
 
 void OpenXrLayer::CachePivotPoseDelta(XrTime time, const XrPosef& pose_delta) {
     cached_pivot_pose_deltas_[time] = pose_delta;
+    while (cached_pivot_pose_deltas_.size() > kMaxCachedPivotPoseFrames) {
+        cached_pivot_pose_deltas_.erase(cached_pivot_pose_deltas_.begin());
+    }
 }
 
 bool OpenXrLayer::FindPivotPoseDelta(XrTime time, XrPosef* pose_delta, XrTime* matched_time) const {
@@ -6598,14 +7040,14 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
         *synthesized_quad_views = false;
     }
 
-    bool quadviews_active = false;
+    bool quadviews_emulation_active = false;
     bool varjo_compatible = false;
     QuadViewsResolvedSettings quadviews_settings;
     {
         std::scoped_lock lock(mutex_);
         ReloadConfigIfNeeded();
         RefreshResolvedSettings();
-        quadviews_active = IsQuadViewsActive();
+        quadviews_emulation_active = IsQuadViewsEmulationActive();
         varjo_compatible = varjo_compatible_quadviews_active_;
         quadviews_settings = resolved_settings_.quadviews;
     }
@@ -6614,7 +7056,7 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
     // Varjo foveated-rendering next chain, which the runtime consumes to place the
     // focus inset by gaze — and return the runtime's real 4 views. No stereo remap,
     // no synthesis. Pivot is still applied downstream in LocateViews.
-    if (varjo_compatible && view_locate_info && quadviews_active &&
+    if (varjo_compatible && view_locate_info &&
         IsQuadViewConfiguration(view_locate_info->viewConfigurationType)) {
         return next_locate_views_(
             session, view_locate_info, view_state, view_capacity_input, view_count_output, views);
@@ -6631,7 +7073,8 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
         }
     }
 
-    if (!view_locate_info || !IsQuadViewConfiguration(view_locate_info->viewConfigurationType) || !quadviews_active) {
+    if (!view_locate_info || !IsQuadViewConfiguration(view_locate_info->viewConfigurationType) ||
+        !quadviews_emulation_active) {
         const bool diag = TurboSequencedDebugTick();
         if (diag) {
             logger_.Debug("Turbo-diag: app xrLocateViews starting (no lock held).");
@@ -6668,7 +7111,9 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
         logger_.Debug("Turbo-diag: synthesized-quadviews xrLocateViews completed.");
     }
     if (view_state && XR_SUCCEEDED(result)) {
+        void* app_next = view_state->next;
         *view_state = runtime_view_state;
+        view_state->next = app_next;
     }
     if (XR_FAILED(result)) {
         return result;
@@ -6702,9 +7147,34 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
                                                             &focus_yaw_radians,
                                                             &focus_pitch_radians);
         if (!has_eye_focus) {
-            quadviews_smoothed_focus_yaw_radians_ = 0.0;
-            quadviews_smoothed_focus_pitch_radians_ = 0.0;
-            quadviews_last_focus_smoothing_wall_time_.reset();
+            // Blinks and brief tracker dropouts should not snap the focus inset
+            // back to center. Hold the last valid gaze briefly, then ease home
+            // if tracking remains unavailable.
+            constexpr std::chrono::milliseconds kGazeHoldDuration{500};
+            const auto now = std::chrono::steady_clock::now();
+            const bool hold_last_gaze = quadviews_last_valid_gaze_wall_time_.has_value() &&
+                                        now - *quadviews_last_valid_gaze_wall_time_ <= kGazeHoldDuration;
+            if (!hold_last_gaze && quadviews_last_valid_gaze_wall_time_.has_value()) {
+                double delta_seconds = 0.0;
+                if (quadviews_last_focus_smoothing_wall_time_.has_value()) {
+                    delta_seconds = std::chrono::duration<double>(
+                                        now - *quadviews_last_focus_smoothing_wall_time_)
+                                        .count();
+                }
+                const double release_blend =
+                    ComputeTimeBasedBlend(std::max(0.9, quadviews_settings.gaze_smoothing), delta_seconds);
+                quadviews_smoothed_focus_yaw_radians_ *= 1.0 - release_blend;
+                quadviews_smoothed_focus_pitch_radians_ *= 1.0 - release_blend;
+                if (NearlyZero(quadviews_smoothed_focus_yaw_radians_) &&
+                    NearlyZero(quadviews_smoothed_focus_pitch_radians_)) {
+                    quadviews_smoothed_focus_yaw_radians_ = 0.0;
+                    quadviews_smoothed_focus_pitch_radians_ = 0.0;
+                    quadviews_last_valid_gaze_wall_time_.reset();
+                }
+            }
+            quadviews_last_focus_smoothing_wall_time_ = now;
+            focus_yaw_radians = quadviews_smoothed_focus_yaw_radians_;
+            focus_pitch_radians = quadviews_smoothed_focus_pitch_radians_;
         }
     }
 
@@ -6735,10 +7205,17 @@ bool OpenXrLayer::SynthesizeQuadViewsFromStereo(std::span<const XrView> stereo_v
     }
 
     *view_count_output = 4;
+    std::array<void*, 4> app_next{};
+    for (uint32_t i = 0; i < app_next.size(); ++i) {
+        app_next[i] = views[i].next;
+    }
     views[0] = stereo_views[0];
     views[1] = stereo_views[1];
     views[2] = stereo_views[0];
     views[3] = stereo_views[1];
+    for (uint32_t i = 0; i < app_next.size(); ++i) {
+        views[i].next = app_next[i];
+    }
 
     views[2].fov = BuildFocusFov(stereo_views[0].fov, quadviews_settings, focus_yaw_radians, focus_pitch_radians);
     views[3].fov = BuildFocusFov(stereo_views[1].fov, quadviews_settings, focus_yaw_radians, focus_pitch_radians);
@@ -7163,7 +7640,7 @@ bool OpenXrLayer::ShouldDeferSwapchainRelease(const SwapchainInfo& info) const {
 XrResult OpenXrLayer::FlushDeferredSwapchainReleaseLocked(XrSwapchain swapchain,
                                                           SwapchainInfo& info,
                                                           std::string_view reason) {
-    if (!info.release_deferred) {
+    if (info.deferred_release_count == 0) {
         return XR_SUCCESS;
     }
     if (!next_release_swapchain_image_) {
@@ -7172,16 +7649,19 @@ XrResult OpenXrLayer::FlushDeferredSwapchainReleaseLocked(XrSwapchain swapchain,
         return XR_ERROR_RUNTIME_FAILURE;
     }
 
-    XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
-    const XrResult result = next_release_swapchain_image_(swapchain, &release_info);
-    if (XR_FAILED(result)) {
-        logger_.Error("Deferred swapchain release failed: handle=" + FormatHandle(swapchain) +
-                      ", reason=" + std::string(reason) +
-                      ", result=" + FormatHex(static_cast<uint64_t>(result)));
-        return result;
+    while (info.deferred_release_count > 0) {
+        XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+        const XrResult result = next_release_swapchain_image_(swapchain, &release_info);
+        if (XR_FAILED(result)) {
+            logger_.Error("Deferred swapchain release failed: handle=" + FormatHandle(swapchain) +
+                          ", reason=" + std::string(reason) +
+                          ", remaining=" + std::to_string(info.deferred_release_count) +
+                          ", result=" + FormatHex(static_cast<uint64_t>(result)));
+            return result;
+        }
+        --info.deferred_release_count;
+        info.image_states.ReleaseDownstreamOldest();
     }
-
-    info.release_deferred = false;
     if (info.quadviews_session && info.release_count <= 3) {
         LogSwapchainSummary(swapchain, info, "deferredReleaseFlushed");
     }
@@ -7416,15 +7896,25 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
         UINT viewport_count{D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE};
         D3D11_PRIMITIVE_TOPOLOGY topology{D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED};
     } saved;
-    context->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, &saved.depth_stencil);
-    context->VSGetShader(&saved.vertex_shader, nullptr, nullptr);
-    context->PSGetShader(&saved.pixel_shader, nullptr, nullptr);
-    context->IAGetInputLayout(&saved.input_layout);
-    context->IAGetPrimitiveTopology(&saved.topology);
-    context->PSGetShaderResources(0, 1, saved.shader_resources);
-    context->PSGetSamplers(0, 1, saved.samplers);
-    context->PSGetConstantBuffers(0, 1, saved.constant_buffers);
-    context->RSGetViewports(&saved.viewport_count, saved.viewports);
+    ID3DDeviceContextState* application_context_state = nullptr;
+    const bool use_context_state = d3d11_quadviews_compositor_.context1 &&
+                                   d3d11_quadviews_compositor_.layer_context_state;
+    if (use_context_state) {
+        d3d11_quadviews_compositor_.context1->SwapDeviceContextState(
+            d3d11_quadviews_compositor_.layer_context_state, &application_context_state);
+        context->ClearState();
+    } else {
+        context->OMGetRenderTargets(
+            D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, &saved.depth_stencil);
+        context->VSGetShader(&saved.vertex_shader, nullptr, nullptr);
+        context->PSGetShader(&saved.pixel_shader, nullptr, nullptr);
+        context->IAGetInputLayout(&saved.input_layout);
+        context->IAGetPrimitiveTopology(&saved.topology);
+        context->PSGetShaderResources(0, 1, saved.shader_resources);
+        context->PSGetSamplers(0, 1, saved.samplers);
+        context->PSGetConstantBuffers(0, 1, saved.constant_buffers);
+        context->RSGetViewports(&saved.viewport_count, saved.viewports);
+    }
 
     uint32_t sharpened_count = 0;
     // Why each focus view was skipped, for the one-shot diagnostic below — the
@@ -7433,10 +7923,8 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
     for (uint32_t i = 2; i < 4; ++i) {
         const char*& reason = skip_reason[i - 2];
         XrCompositionLayerProjectionView& view = views[i];
-        // Only single-slice focus swapchains are supported for the sharpen pass; an
-        // arrayed subImage falls back to the app's unsharpened focus.
-        if (view.subImage.imageArrayIndex != 0 || view.subImage.swapchain == XR_NULL_HANDLE) {
-            reason = "arrayed or null subImage";
+        if (view.subImage.swapchain == XR_NULL_HANDLE) {
+            reason = "null subImage";
             continue;
         }
         const auto it = tracked_swapchains_.find(view.subImage.swapchain);
@@ -7446,6 +7934,15 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
             continue;
         }
         SwapchainInfo& src = it->second;
+        const uint32_t array_slice = view.subImage.imageArrayIndex;
+        if (array_slice >= std::max<uint32_t>(1, src.array_size)) {
+            reason = "array slice out of range";
+            continue;
+        }
+        if (src.array_size != 1) {
+            reason = "array focus sharpen is unsupported; forwarding unsharpened";
+            continue;
+        }
         // This frame's content: the last-released image (turbo pipelining can
         // advance last_acquired past it before EndFrame runs).
         const uint32_t src_index = src.has_last_released_image_index ? src.last_released_image_index
@@ -7454,12 +7951,14 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
             reason = "image index out of range";
             continue;
         }
-        if (!EnsureD3D11SwapchainShaderResources(src) ||
-            src_index >= src.d3d11_shader_resources.size()) {
+        const size_t shader_resource_slot =
+            src_index * std::max<uint32_t>(1, src.array_size) + array_slice;
+        if (!EnsureD3D11SwapchainShaderResources(src, array_slice) ||
+            shader_resource_slot >= src.d3d11_shader_resources.size()) {
             reason = "no shader resource views (focus swapchain needs sampled usage)";
             continue;
         }
-        ID3D11ShaderResourceView* focus_srv = src.d3d11_shader_resources[src_index];
+        ID3D11ShaderResourceView* focus_srv = src.d3d11_shader_resources[shader_resource_slot];
         if (!focus_srv) {
             reason = "null shader resource view";
             continue;
@@ -7481,7 +7980,7 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
             continue;
         }
         XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
-        wait_info.timeout = XR_INFINITE_DURATION;
+        wait_info.timeout = kInternalSwapchainWaitTimeout;
         result = next_wait_swapchain_image_(target.swapchain, &wait_info);
         if (XR_FAILED(result)) {
             XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
@@ -7547,30 +8046,36 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
     }
 
     // Restore app context state.
-    context->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, saved.depth_stencil);
-    context->VSSetShader(saved.vertex_shader, nullptr, 0);
-    context->PSSetShader(saved.pixel_shader, nullptr, 0);
-    context->IASetInputLayout(saved.input_layout);
-    context->IASetPrimitiveTopology(saved.topology);
-    context->PSSetShaderResources(0, 1, saved.shader_resources);
-    context->PSSetSamplers(0, 1, saved.samplers);
-    context->PSSetConstantBuffers(0, 1, saved.constant_buffers);
-    context->RSSetViewports(saved.viewport_count, saved.viewports);
-    for (ID3D11RenderTargetView*& rtv : saved.render_targets) {
-        SafeRelease(rtv);
-    }
-    SafeRelease(saved.depth_stencil);
-    SafeRelease(saved.vertex_shader);
-    SafeRelease(saved.pixel_shader);
-    SafeRelease(saved.input_layout);
-    for (ID3D11ShaderResourceView*& resource : saved.shader_resources) {
-        SafeRelease(resource);
-    }
-    for (ID3D11SamplerState*& sampler : saved.samplers) {
-        SafeRelease(sampler);
-    }
-    for (ID3D11Buffer*& buffer : saved.constant_buffers) {
-        SafeRelease(buffer);
+    if (use_context_state) {
+        d3d11_quadviews_compositor_.context1->SwapDeviceContextState(application_context_state, nullptr);
+        SafeRelease(application_context_state);
+    } else {
+        context->OMSetRenderTargets(
+            D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, saved.render_targets, saved.depth_stencil);
+        context->VSSetShader(saved.vertex_shader, nullptr, 0);
+        context->PSSetShader(saved.pixel_shader, nullptr, 0);
+        context->IASetInputLayout(saved.input_layout);
+        context->IASetPrimitiveTopology(saved.topology);
+        context->PSSetShaderResources(0, 1, saved.shader_resources);
+        context->PSSetSamplers(0, 1, saved.samplers);
+        context->PSSetConstantBuffers(0, 1, saved.constant_buffers);
+        context->RSSetViewports(saved.viewport_count, saved.viewports);
+        for (ID3D11RenderTargetView*& rtv : saved.render_targets) {
+            SafeRelease(rtv);
+        }
+        SafeRelease(saved.depth_stencil);
+        SafeRelease(saved.vertex_shader);
+        SafeRelease(saved.pixel_shader);
+        SafeRelease(saved.input_layout);
+        for (ID3D11ShaderResourceView*& resource : saved.shader_resources) {
+            SafeRelease(resource);
+        }
+        for (ID3D11SamplerState*& sampler : saved.samplers) {
+            SafeRelease(sampler);
+        }
+        for (ID3D11Buffer*& buffer : saved.constant_buffers) {
+            SafeRelease(buffer);
+        }
     }
 
     if (sharpened_count > 0) {
@@ -7626,6 +8131,8 @@ void OpenXrLayer::ResetD3D11QuadViewsCompositor() {
     SafeRelease(d3d11_quadviews_compositor_.sampler);
     SafeRelease(d3d11_quadviews_compositor_.pixel_shader);
     SafeRelease(d3d11_quadviews_compositor_.vertex_shader);
+    SafeRelease(d3d11_quadviews_compositor_.layer_context_state);
+    SafeRelease(d3d11_quadviews_compositor_.context1);
     SafeRelease(d3d11_quadviews_compositor_.context);
     SafeRelease(d3d11_quadviews_compositor_.device);
     d3d11_quadviews_compositor_.initialized = false;
@@ -7662,7 +8169,8 @@ void OpenXrLayer::LogSwapchainSummary(XrSwapchain swapchain,
            << ", acquires=" << info.acquire_count
            << ", waits=" << info.wait_count
            << ", releases=" << info.release_count
-           << ", releaseDeferred=" << info.release_deferred
+           << ", deferredReleases=" << info.deferred_release_count
+           << ", imageStates=" << info.image_states.Size()
            << ", trackedSwapchains=" << tracked_swapchains_.size();
     if (info.quadviews_session) {
         logger_.Info(stream.str());

--- a/layer/src/runtime_pacing.cpp
+++ b/layer/src/runtime_pacing.cpp
@@ -1,12 +1,25 @@
 #include "depthxr/runtime_pacing.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <exception>
 #include <fstream>
+#include <functional>
 #include <regex>
 #include <sstream>
 #include <system_error>
+#include <thread>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#endif
 
 namespace depthxr {
 namespace {
@@ -108,13 +121,16 @@ std::string ExtractString(const std::string& object, const std::string& key) {
 std::string SerializeObservations(const std::vector<RuntimePacingObservation>& observations) {
     std::ostringstream stream;
     stream << "{\n";
-    stream << "  \"version\": 1,\n";
+    stream << "  \"version\": 2,\n";
     stream << "  \"observations\": [\n";
     for (size_t i = 0; i < observations.size(); ++i) {
         const RuntimePacingObservation& observation = observations[i];
         stream << "    {\n";
         stream << "      \"runtimeName\": \"" << EscapeJsonString(observation.runtime_name) << "\",\n";
         stream << "      \"runtimeVersion\": \"" << EscapeJsonString(observation.runtime_version) << "\",\n";
+        stream << "      \"systemName\": \"" << EscapeJsonString(observation.system_name) << "\",\n";
+        stream << "      \"vendorId\": " << observation.vendor_id << ",\n";
+        stream << "      \"graphicsApi\": \"" << EscapeJsonString(observation.graphics_api) << "\",\n";
         stream << "      \"mode\": \"" << ToString(observation.mode) << "\",\n";
         stream << "      \"source\": \"" << EscapeJsonString(observation.source) << "\",\n";
         stream << "      \"layerVersion\": \"" << EscapeJsonString(observation.layer_version) << "\",\n";
@@ -145,7 +161,10 @@ bool WriteFileAtomically(const std::filesystem::path& path, const std::string& c
         }
     }
 
-    const std::filesystem::path temporary_path = path.string() + ".tmp";
+    const auto unique_suffix = std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count()) + "." +
+        std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    const std::filesystem::path temporary_path = path.string() + ".tmp." + unique_suffix;
     {
         std::ofstream stream(temporary_path, std::ios::trunc);
         if (!stream) {
@@ -157,6 +176,18 @@ bool WriteFileAtomically(const std::filesystem::path& path, const std::string& c
         stream << content;
     }
 
+#if defined(_WIN32)
+    if (!MoveFileExW(temporary_path.c_str(),
+                     path.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        const DWORD move_error = GetLastError();
+        std::filesystem::remove(temporary_path, ec);
+        if (error) {
+            *error = "Unable to replace runtime-pacing file: Win32 error " + std::to_string(move_error);
+        }
+        return false;
+    }
+#else
     std::filesystem::remove(path, ec);
     ec.clear();
     std::filesystem::rename(temporary_path, path, ec);
@@ -167,6 +198,7 @@ bool WriteFileAtomically(const std::filesystem::path& path, const std::string& c
         }
         return false;
     }
+#endif
     return true;
 }
 
@@ -208,6 +240,9 @@ std::vector<RuntimePacingObservation> ReadRuntimePacingObservations(const std::f
             continue;
         }
         observation.runtime_version = ExtractString(object, "runtimeVersion");
+        observation.system_name = ExtractString(object, "systemName");
+        observation.vendor_id = static_cast<std::uint32_t>(ExtractInteger(object, "vendorId", 0));
+        observation.graphics_api = ExtractString(object, "graphicsApi");
         observation.mode = ParseTurboPacingMode(ExtractString(object, "mode")).value_or(TurboPacingMode::kAsync);
         observation.source = ExtractString(object, "source");
         observation.layer_version = ExtractString(object, "layerVersion");
@@ -222,9 +257,17 @@ std::vector<RuntimePacingObservation> ReadRuntimePacingObservations(const std::f
 }
 
 std::optional<RuntimePacingObservation> FindRuntimePacingObservation(const std::filesystem::path& path,
-                                                                     const std::string& runtime_name) {
+                                                                     const std::string& runtime_name,
+                                                                     const std::string& system_name,
+                                                                     std::uint32_t vendor_id,
+                                                                     const std::string& graphics_api) {
     for (RuntimePacingObservation& observation : ReadRuntimePacingObservations(path)) {
-        if (observation.runtime_name == runtime_name) {
+        const bool runtime_matches = observation.runtime_name == runtime_name;
+        const bool fingerprint_requested = !system_name.empty() || vendor_id != 0 || !graphics_api.empty();
+        const bool fingerprint_matches = observation.system_name == system_name &&
+                                         observation.vendor_id == vendor_id &&
+                                         observation.graphics_api == graphics_api;
+        if (runtime_matches && (!fingerprint_requested || fingerprint_matches)) {
             return std::move(observation);
         }
     }
@@ -241,7 +284,10 @@ bool RecordRuntimePacingObservation(const std::filesystem::path& path,
     std::vector<RuntimePacingObservation> observations = ReadRuntimePacingObservations(path);
     auto existing = std::find_if(observations.begin(), observations.end(),
                                  [&](const RuntimePacingObservation& candidate) {
-                                     return candidate.runtime_name == observation.runtime_name;
+                                     return candidate.runtime_name == observation.runtime_name &&
+                                            candidate.system_name == observation.system_name &&
+                                            candidate.vendor_id == observation.vendor_id &&
+                                            candidate.graphics_api == observation.graphics_api;
                                  });
 
     if (existing == observations.end()) {

--- a/layer/src/swapchain_state.cpp
+++ b/layer/src/swapchain_state.cpp
@@ -1,0 +1,66 @@
+#include "depthxr/swapchain_state.h"
+
+#include <algorithm>
+
+namespace depthxr {
+
+void SwapchainImageQueue::Acquire(uint32_t image_index) {
+    states_.push_back({image_index, false, false, false});
+}
+
+std::optional<uint32_t> SwapchainImageQueue::WaitOldest() {
+    const auto pending = std::find_if(states_.begin(), states_.end(), [](const ImageState& state) {
+        return !state.waited;
+    });
+    if (pending == states_.end()) {
+        return std::nullopt;
+    }
+    pending->waited = true;
+    return pending->index;
+}
+
+std::optional<uint32_t> SwapchainImageQueue::ReleaseOldest() {
+    const auto pending = std::find_if(states_.begin(), states_.end(), [](const ImageState& state) {
+        return state.waited && !state.app_released;
+    });
+    if (pending == states_.end()) {
+        return std::nullopt;
+    }
+    pending->app_released = true;
+    return pending->index;
+}
+
+std::optional<uint32_t> SwapchainImageQueue::ReleaseDownstreamOldest() {
+    const auto pending = std::find_if(states_.begin(), states_.end(), [](const ImageState& state) {
+        return state.app_released && !state.downstream_released;
+    });
+    if (pending == states_.end()) {
+        return std::nullopt;
+    }
+    pending->downstream_released = true;
+    const uint32_t index = pending->index;
+    RetireReleasedPrefix();
+    return index;
+}
+
+void SwapchainImageQueue::Clear() {
+    states_.clear();
+}
+
+size_t SwapchainImageQueue::Size() const {
+    return states_.size();
+}
+
+size_t SwapchainImageQueue::PendingDownstreamReleases() const {
+    return static_cast<size_t>(std::count_if(states_.begin(), states_.end(), [](const ImageState& state) {
+        return state.app_released && !state.downstream_released;
+    }));
+}
+
+void SwapchainImageQueue::RetireReleasedPrefix() {
+    while (!states_.empty() && states_.front().downstream_released) {
+        states_.pop_front();
+    }
+}
+
+} // namespace depthxr

--- a/layer/src/util/logger.cpp
+++ b/layer/src/util/logger.cpp
@@ -95,6 +95,9 @@ std::string FormatRepeatedDuration(std::chrono::system_clock::duration duration)
 Logger::~Logger() {
     std::scoped_lock lock(mutex_);
     FlushPendingDuplicateLocked();
+    if (stream_.is_open()) {
+        stream_.flush();
+    }
 }
 
 void Logger::Initialize(const std::filesystem::path& log_path) {
@@ -110,6 +113,7 @@ void Logger::Initialize(const std::filesystem::path& log_path) {
         stream_.close();
     }
     active_log_path_ = CreateSessionLogPath(base_log_path_);
+    last_stream_flush_time_ = {};
     PruneLocked();
 }
 
@@ -209,8 +213,9 @@ void Logger::WriteLineLocked(LogLevel level,
         return;
     }
 
-    // Reuse one open handle instead of reopening the file per line; flush so
-    // the log stays readable while the layer is loaded in a running app.
+    // Reuse one open handle instead of reopening the file per line. Debug and
+    // heartbeat messages can originate on the frame path, so batch ordinary
+    // flushes briefly; errors remain immediately durable.
     if (!stream_.is_open()) {
         stream_.open(active_log_path_, std::ios::app);
         if (!stream_.is_open()) {
@@ -222,7 +227,13 @@ void Logger::WriteLineLocked(LogLevel level,
     const std::tm tm = LocalTime(time);
 
     stream_ << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " [" << ToString(level) << "] " << message << '\n';
-    stream_.flush();
+    constexpr std::chrono::milliseconds kFlushInterval{250};
+    const auto flush_now = std::chrono::steady_clock::now();
+    if (level == LogLevel::Error || last_stream_flush_time_ == std::chrono::steady_clock::time_point{} ||
+        flush_now - last_stream_flush_time_ >= kFlushInterval) {
+        stream_.flush();
+        last_stream_flush_time_ = flush_now;
+    }
 }
 
 void Logger::Write(LogLevel level, const std::string& message) {

--- a/layer/tests/config_tests.cpp
+++ b/layer/tests/config_tests.cpp
@@ -12,6 +12,7 @@
 #include "depthxr/runtime_pacing.h"
 #include "depthxr/seen_apps.h"
 #include "depthxr/settings_resolver.h"
+#include "depthxr/swapchain_state.h"
 #include "depthxr/turbo_metrics.h"
 
 namespace {
@@ -1343,6 +1344,9 @@ void TestRuntimePacingObservationRoundTrip() {
     depthxr::RuntimePacingObservation first;
     first.runtime_name = "Oculus";
     first.runtime_version = "1.205.0";
+    first.system_name = "Quest 3";
+    first.vendor_id = 1;
+    first.graphics_api = "D3D11";
     first.mode = depthxr::TurboPacingMode::kSequenced;
     first.source = "discovered";
     first.layer_version = "0.13.0";
@@ -1360,6 +1364,14 @@ void TestRuntimePacingObservationRoundTrip() {
     Expect(depthxr::RecordRuntimePacingObservation(path, second, &record_error),
            "Failed to record second runtime pacing observation: " + record_error);
 
+    depthxr::RuntimePacingObservation second_oculus_system = first;
+    second_oculus_system.system_name = "Crystal";
+    second_oculus_system.vendor_id = 2;
+    second_oculus_system.mode = depthxr::TurboPacingMode::kAsync;
+    second_oculus_system.last_used_unix_seconds = 250;
+    Expect(depthxr::RecordRuntimePacingObservation(path, second_oculus_system, &record_error),
+           "Failed to record second headset fingerprint for one runtime: " + record_error);
+
     // Upsert: a later verdict for the same runtime replaces the mode but
     // preserves first-used.
     first.mode = depthxr::TurboPacingMode::kAsync;
@@ -1368,7 +1380,7 @@ void TestRuntimePacingObservationRoundTrip() {
            "Failed to upsert runtime pacing observation: " + record_error);
 
     const auto observations = depthxr::ReadRuntimePacingObservations(path);
-    Expect(observations.size() == 2, "Runtime pacing observation count mismatch");
+    Expect(observations.size() == 3, "Runtime pacing observation fingerprint count mismatch");
 
     const auto oculus = depthxr::FindRuntimePacingObservation(path, "Oculus");
     Expect(oculus.has_value(), "Oculus runtime pacing observation missing");
@@ -1377,6 +1389,12 @@ void TestRuntimePacingObservationRoundTrip() {
     Expect(oculus->last_used_unix_seconds == 300, "Last-used timestamp was not updated on upsert");
     Expect(oculus->runtime_version == "1.205.0", "Runtime version mismatch");
     Expect(oculus->source == "discovered", "Source mismatch");
+
+    const auto quest = depthxr::FindRuntimePacingObservation(path, "Oculus", "Quest 3", 1, "D3D11");
+    Expect(quest.has_value(), "Exact runtime/headset/graphics fingerprint was not found");
+    Expect(quest->mode == depthxr::TurboPacingMode::kAsync, "Exact fingerprint upsert mode mismatch");
+    const auto crystal = depthxr::FindRuntimePacingObservation(path, "Oculus", "Crystal", 2, "D3D11");
+    Expect(crystal.has_value(), "Second headset fingerprint was collapsed into the first");
 
     const auto steam = depthxr::FindRuntimePacingObservation(path, "SteamVR/OpenXR");
     Expect(steam.has_value(), "SteamVR runtime pacing observation missing");
@@ -1535,6 +1553,29 @@ void TestLoggerCollapsesDuplicateMessages() {
     std::filesystem::remove_all(test_directory, error);
 }
 
+void TestSwapchainImageQueuePreservesFifo() {
+    depthxr::SwapchainImageQueue queue;
+    queue.Acquire(2);
+    queue.Acquire(0);
+    Expect(queue.Size() == 2, "Swapchain queue did not retain both acquired images");
+
+    Expect(queue.WaitOldest() == 2, "First wait did not target the oldest acquired image");
+    Expect(queue.WaitOldest() == 0, "Second wait did not advance to the next acquired image");
+    Expect(!queue.WaitOldest().has_value(), "Wait succeeded without an un-waited acquired image");
+
+    Expect(queue.ReleaseOldest() == 2, "First app release did not target the oldest waited image");
+    Expect(queue.ReleaseOldest() == 0, "Second app release did not preserve FIFO order");
+    Expect(queue.PendingDownstreamReleases() == 2,
+           "Deferred downstream release count did not retain both app releases");
+
+    Expect(queue.ReleaseDownstreamOldest() == 2,
+           "First downstream release did not target the oldest app-released image");
+    Expect(queue.Size() == 1, "Completed FIFO prefix was not retired");
+    Expect(queue.ReleaseDownstreamOldest() == 0,
+           "Second downstream release did not target the remaining image");
+    Expect(queue.Size() == 0, "Fully released queue was not emptied");
+}
+
 } // namespace
 
 int main() {
@@ -1566,6 +1607,7 @@ int main() {
     TestQuadViewConvergenceKeepsInsetOffsetsAligned();
     TestPivotYawAmplifiesBeyondDeadzone();
     TestPivotYawNoOpInsideDeadzone();
+    TestSwapchainImageQueuePreservesFifo();
     TestLoggerCollapsesDuplicateMessages();
     std::cout << "depthxr_layer_tests passed\n";
     return 0;


### PR DESCRIPTION
## Summary

- Refactor Turbo frame pacing around a persistent worker, explicit session teardown, and off-frame persistence to reduce overhead and improve lifecycle safety.
- Reorganize Turbo into focused Runtime Behavior and Performance Diagnostics pages while keeping everyday configuration simple.
- Harden Quadviews swapchain tracking, D3D11 state preservation, array/subimage handling, gaze continuity, and native Varjo extension behavior.
- Reduce redundant Pivot/gaze work, batch normal log flushing, and reject unsupported multi-instance/session use safely.
- Add opinionated Quadviews performance presets and advance VectorXR to 0.13.0.

## Compatibility boundaries

- Synthesized Quadviews remains intentionally limited to D3D11 applications.
- Native Varjo Quadviews stays transparent when the VectorXR profile is disabled and receives VectorXR scaling/sharpening when enabled.
- Additional OpenXR instances/sessions are rejected safely; a full per-handle dispatch map remains future work.

## Validation

- cmake --build build --config Release
- ctest --test-dir build -C Release --output-on-failure
- npm run build
- cargo check --locked
- Fresh npm run installer:build producing the 0.13.0 NSIS installer
- DCS and MSFS 2024 flight testing on Pimax OpenXR/D3D11
- Latest DCS A/B: 124 seconds per state, average FPS within 0.2%, zero Turbo stalls/timeouts, balanced swapchain lifecycle, and no warnings/errors