### PR TITLE
0.13.3

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.13.2"
+version = "0.13.3"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/lib/patchNotes.ts
+++ b/app/src/lib/patchNotes.ts
@@ -8,6 +8,19 @@ export interface PatchNoteEntry {
 
 export const patchNotes: PatchNoteEntry[] = [
   {
+    version: '0.13.3',
+    date: '2026-07-15',
+    title: 'Headset Recovery & Frame Pacing',
+    summary: 'Restores gaze-driven rendering after Virtual Desktop reconnects, activates native Varjo foveation when DCS omits its request, and fixes inactive-layer and Quadviews prewarm paths that could disrupt frame pacing.',
+    items: [
+      'Fixed Virtual Desktop reconnects leaving synthesized Quadviews visually stuck on a stale focus region: after a sustained eye-gaze locate failure recovers, VectorXR now rebuilds the compositor output targets so live gaze control returns without restarting the game.',
+      'Fixed native Varjo eye-tracked Quadviews when DCS enables the Varjo extension but omits its per-view foveated-rendering request; VectorXR now supplies the request while eye tracking is active, allowing the runtime to return its foveated texture sizes and moving focus geometry.',
+      'Reduced overhead when enhancements are inactive: sessions that never enable Turbo now pass frame pacing directly through, while disabled Pivot, Depth, and Quadviews paths skip unnecessary pose processing.',
+      'Fixed synthesized Quadviews output targets being prewarmed at native stereo size and rebuilt on the first composed frame at the configured focus density, removing a large first-frame stall and a runtime resource-churn path that could keep DCS below headset refresh.',
+      'Expanded Varjo foveation-request and Quadviews compositor-recovery diagnostics, with regression coverage for density scaling and runtime maximum-size clamping.',
+    ],
+  },
+  {
     version: '0.13.2',
     date: '2026-07-14',
     title: 'Pivot Reliability & Headset Compatibility',

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
     STATIC
     src/config_parser.cpp
     src/input_devices.cpp
+    src/quadviews_sizing.cpp
     src/runtime_pacing.cpp
     src/runtime_compatibility.cpp
     src/seen_apps.cpp

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -595,6 +595,12 @@ class OpenXrLayer {
     // state; it is never held across a blocking runtime wait except when
     // spec-ordering requires it (second poll, teardown drains). mutex_ must
     // NOT be required by WaitFrame/BeginFrame, which stay off the config lock.
+    // False when Turbo has never been enabled for the current session. This
+    // gives non-Turbo sessions a literal wait/begin/end pass-through instead
+    // of making SteamVR observe VectorXR's pacing bookkeeping. Once armed it
+    // stays armed until the frame state is reset because an established Turbo
+    // pipeline is structural for the remainder of the session.
+    std::atomic<bool> turbo_frame_interception_required_{false};
     std::mutex turbo_mutex_;
     std::condition_variable turbo_async_worker_cv_;
     std::thread turbo_async_worker_;

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -311,6 +311,7 @@ class OpenXrLayer {
     struct VarjoNativeFoveationDiagnosticState {
         uint64_t locate_calls{0};
         std::array<uint64_t, 3> request_state_counts{}; // absent, present/inactive, present/active
+        uint64_t vector_injected_locate_requests{0};
         uint8_t logged_request_state_mask{0};
         uint64_t successful_quad_locates{0};
         bool focus_ranges_initialized{false};
@@ -411,6 +412,7 @@ class OpenXrLayer {
     void ResetSessionState();
     void ResetInstanceState();
     void ResetD3D11QuadViewsCompositor();
+    void RecycleD3D11QuadViewsCompositionTargets();
     XrResult CreateInternalReferenceSpaces(XrSession session);
     void DestroyInternalReferenceSpaces();
     XrResult CreateEyeGazeResources(XrSession session);
@@ -445,6 +447,7 @@ class OpenXrLayer {
                                 XrView* views,
                                 bool* synthesized_quad_views);
     void RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* view_locate_info,
+                                            bool vector_request_injected,
                                             const XrViewState* view_state,
                                             XrResult result,
                                             uint32_t view_capacity_input,
@@ -842,6 +845,10 @@ class OpenXrLayer {
     double quadviews_smoothed_focus_pitch_radians_{0.0};
     std::optional<std::chrono::steady_clock::time_point> quadviews_last_focus_smoothing_wall_time_;
     std::optional<std::chrono::steady_clock::time_point> quadviews_last_valid_gaze_wall_time_;
+    std::optional<std::chrono::steady_clock::time_point> quadviews_eye_gaze_loss_started_wall_time_;
+    bool quadviews_eye_gaze_loss_was_locate_failure_{false};
+    bool quadviews_has_seen_valid_gaze_{false};
+    bool quadviews_compositor_recovery_pending_{false};
     XrViewConfigurationType active_primary_view_configuration_type_{XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO};
     XrViewConfigurationType active_runtime_view_configuration_type_{XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO};
     bool has_active_primary_view_configuration_{false};

--- a/layer/include/depthxr/quadviews_sizing.h
+++ b/layer/include/depthxr/quadviews_sizing.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace depthxr {
+
+struct QuadViewsCanvasDimensions {
+    uint32_t width{1};
+    uint32_t height{1};
+    double density{1.0};
+};
+
+QuadViewsCanvasDimensions ComputeQuadViewsCanvasDimensions(uint32_t stereo_width,
+                                                           uint32_t stereo_height,
+                                                           uint32_t runtime_max_width,
+                                                           uint32_t runtime_max_height,
+                                                           double focus_scale);
+
+} // namespace depthxr

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -3756,6 +3756,9 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
 XrResult OpenXrLayer::WaitFrame(XrSession session,
                                 const XrFrameWaitInfo* frame_wait_info,
                                 XrFrameState* frame_state) {
+    if (!turbo_frame_interception_required_.load(std::memory_order_acquire)) {
+        return next_wait_frame_(session, frame_wait_info, frame_state);
+    }
     if (!frame_state) {
         return next_wait_frame_(session, frame_wait_info, frame_state);
     }
@@ -3930,6 +3933,9 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
 }
 
 XrResult OpenXrLayer::BeginFrame(XrSession session, const XrFrameBeginInfo* frame_begin_info) {
+    if (!turbo_frame_interception_required_.load(std::memory_order_acquire)) {
+        return next_begin_frame_(session, frame_begin_info);
+    }
     {
         std::scoped_lock lock(turbo_mutex_);
         if (turbo_begin_owed_) {
@@ -3975,6 +3981,11 @@ XrResult OpenXrLayer::BeginFrame(XrSession session, const XrFrameBeginInfo* fram
 XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                                       const XrFrameEndInfo* frame_end_info,
                                       std::unique_lock<std::mutex>& config_lock) {
+    if (!turbo_frame_interception_required_.load(std::memory_order_acquire)) {
+        config_lock.unlock();
+        return next_end_frame_(session, frame_end_info);
+    }
+
     // Black-screen forensics: an app that keeps its frame loop running but
     // stops submitting layers shows a void with no error anywhere (DCS did
     // exactly this on SteamVR, silently, after one rendered frame). The
@@ -5261,6 +5272,7 @@ void OpenXrLayer::ResetTurboFrameState() {
     turbo_cadence_pause_logged_ = false;
     turbo_last_frame_blocked_ms_ = 0.0;
     has_logged_turbo_session_compatibility_block_ = false;
+    turbo_frame_interception_required_.store(false, std::memory_order_release);
 }
 
 XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_end_info) {
@@ -5700,19 +5712,20 @@ XrResult OpenXrLayer::CreateReferenceSpace(XrSession session,
 }
 
 XrResult OpenXrLayer::LocateSpace(XrSpace space, XrSpace base_space, XrTime time, XrSpaceLocation* location) {
-    bool enabled = false;
     bool pivotxr_active = false;
+    bool pivot_processing_required = false;
     {
         std::scoped_lock lock(mutex_);
         ReloadConfigIfNeeded();
         RefreshResolvedSettings();
-        enabled = resolved_settings_.core.enabled;
-        if (enabled) {
+        if (resolved_settings_.core.enabled && resolved_settings_.pivotxr.enabled) {
             pivotxr_active = IsPivotXrActive();
+            pivot_processing_required =
+                pivotxr_active || pivotxr_activation_gain_ > kPivotActivationGainEpsilon;
         }
     }
 
-    if (!enabled) {
+    if (!pivot_processing_required) {
         return next_locate_space_(space, base_space, time, location);
     }
 
@@ -5771,6 +5784,10 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
 
     const uint32_t count = std::min(view_capacity_input, *view_count_output);
     if (count == 0) {
+        return result;
+    }
+    if (!resolved_settings_.pivotxr.enabled && !resolved_settings_.depthxr.enabled &&
+        !IsQuadViewsActive()) {
         return result;
     }
 
@@ -6347,6 +6364,9 @@ void OpenXrLayer::RefreshResolvedSettings() {
     // checks); the result only changes when the config document or the active
     // session changes, so skip the work otherwise.
     if (resolved_settings_generation_ == config_generation_ && resolved_settings_session_ == active_session_) {
+        if (resolved_settings_.core.enabled && resolved_settings_.turbo.enabled) {
+            turbo_frame_interception_required_.store(true, std::memory_order_release);
+        }
         return;
     }
     resolved_settings_generation_ = config_generation_;
@@ -6354,6 +6374,12 @@ void OpenXrLayer::RefreshResolvedSettings() {
 
     const ResolvedRuntimeConfig previous = resolved_settings_;
     resolved_settings_ = ResolveRuntimeConfig(config_, current_exe_name_);
+    if (resolved_settings_.core.enabled && resolved_settings_.turbo.enabled) {
+        // Do not disarm this flag on a live-session settings change: once a
+        // Turbo pipeline has been established, Wait/Begin/End interception is
+        // required until ResetTurboFrameState balances and clears it.
+        turbo_frame_interception_required_.store(true, std::memory_order_release);
+    }
     if (!SameInputBinding(previous.depthxr_bindings.toggle_enabled, resolved_settings_.depthxr_bindings.toggle_enabled) ||
         previous.depthxr.enabled != resolved_settings_.depthxr.enabled) {
         ResetDepthToggleState();

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -1782,6 +1782,10 @@ XrResult OpenXrLayer::EndSession(XrSession session) {
         quadviews_smoothed_focus_pitch_radians_ = 0.0;
         quadviews_last_focus_smoothing_wall_time_.reset();
         quadviews_last_valid_gaze_wall_time_.reset();
+        quadviews_eye_gaze_loss_started_wall_time_.reset();
+        quadviews_eye_gaze_loss_was_locate_failure_ = false;
+        quadviews_has_seen_valid_gaze_ = false;
+        quadviews_compositor_recovery_pending_ = false;
         ResetPivotActivationState();
         ResetDepthToggleState();
         ResetTurboToggleState();
@@ -2114,8 +2118,40 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
         // views (0/1) by peripheral_scale, focus views (2/3) by focus_scale. Every
         // other quadviews setting is runtime-owned in this mode.
         ++varjo_native_view_configuration_calls_;
+
+        // DCS enables XR_VARJO_foveated_rendering but does not attach the
+        // per-view request that tells the Varjo runtime to return the texture
+        // sizes for dynamic foveation. When VectorXR eye tracking is enabled,
+        // supply that missing request downstream without changing the app's
+        // next chains. Respect an explicit app request, including inactive.
+        const bool request_native_foveated_views =
+            varjo_foveated_rendering_extension_requested_ &&
+            resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye;
+        std::vector<XrViewConfigurationView> downstream_views_storage;
+        std::vector<XrFoveatedViewConfigurationViewVARJO> injected_foveated_requests;
+        XrViewConfigurationView* downstream_views = views;
+        uint64_t vector_foveated_request_injected_mask = 0;
+        if (request_native_foveated_views && views && view_capacity_input > 0) {
+            downstream_views_storage.assign(views, views + view_capacity_input);
+            injected_foveated_requests.resize(view_capacity_input);
+            for (uint32_t i = 0; i < view_capacity_input; ++i) {
+                if (FindStructInChain(views[i].next,
+                                      XR_TYPE_FOVEATED_VIEW_CONFIGURATION_VIEW_VARJO)) {
+                    continue;
+                }
+                XrFoveatedViewConfigurationViewVARJO& request = injected_foveated_requests[i];
+                request = {XR_TYPE_FOVEATED_VIEW_CONFIGURATION_VIEW_VARJO};
+                request.next = downstream_views_storage[i].next;
+                request.foveatedRenderingActive = XR_TRUE;
+                downstream_views_storage[i].next = &request;
+                if (i < 64) {
+                    vector_foveated_request_injected_mask |= uint64_t{1} << i;
+                }
+            }
+            downstream_views = downstream_views_storage.data();
+        }
         const XrResult native_result = next_enumerate_view_configuration_views_(
-            instance, system_id, view_configuration_type, view_capacity_input, view_count_output, views);
+            instance, system_id, view_configuration_type, view_capacity_input, view_count_output, downstream_views);
         if (XR_FAILED(native_result)) {
             return native_result;
         }
@@ -2131,6 +2167,18 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
                 has_logged_varjo_native_view_configuration_count_ = true;
             }
             return native_result;
+        }
+
+        // Copy only the base structure fields returned by the runtime. The app
+        // owns its next chains, so never expose pointers to our temporary
+        // foveation request structures.
+        if (!downstream_views_storage.empty()) {
+            const uint32_t returned = std::min<uint32_t>(view_capacity_input, *view_count_output);
+            for (uint32_t i = 0; i < returned; ++i) {
+                void* app_next = views[i].next;
+                views[i] = downstream_views_storage[i];
+                views[i].next = app_next;
+            }
         }
         const double peripheral_scale = resolved_settings_.quadviews.peripheral_scale;
         const double focus_scale = resolved_settings_.quadviews.focus_scale;
@@ -2150,6 +2198,7 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
             double requested_scale{1.0};
             bool foveated_request_present{false};
             bool foveated_request_active{false};
+            bool vector_foveated_request_injected{false};
             bool clamped_to_runtime_max{false};
         };
         std::vector<NativeViewDiagnostic> diagnostics;
@@ -2177,6 +2226,8 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
             diagnostic.foveated_request_present = foveated_request != nullptr;
             diagnostic.foveated_request_active =
                 foveated_request && foveated_request->foveatedRenderingActive == XR_TRUE;
+            diagnostic.vector_foveated_request_injected =
+                i < 64 && (vector_foveated_request_injected_mask & (uint64_t{1} << i)) != 0;
             if (i < 64 && diagnostic.foveated_request_present) {
                 foveated_request_present_mask |= uint64_t{1} << i;
             }
@@ -2201,7 +2252,7 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
         std::ostringstream signature;
         signature << applied << ":" << FormatDiagnosticDouble(peripheral_scale) << ":"
                   << FormatDiagnosticDouble(focus_scale) << ":" << foveated_request_present_mask << ":"
-                  << foveated_request_active_mask;
+                  << foveated_request_active_mask << ":" << vector_foveated_request_injected_mask;
         for (const NativeViewDiagnostic& diagnostic : diagnostics) {
             signature << ":" << diagnostic.runtime_recommended_width << "x"
                       << diagnostic.runtime_recommended_height << "/" << diagnostic.runtime_max_width << "x"
@@ -2232,6 +2283,8 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
                    << ", appCapacity=" << view_capacity_input
                    << ", appFoveatedTextureRequestPresentMask=" << FormatHex(foveated_request_present_mask)
                    << ", appFoveatedTextureRequestActiveMask=" << FormatHex(foveated_request_active_mask)
+                   << ", vectorFoveatedTextureRequestInjectedMask="
+                   << FormatHex(vector_foveated_request_injected_mask)
                    << ", vectorPeripheralScale=" << FormatDiagnosticDouble(peripheral_scale)
                    << ", vectorFocusScale=" << FormatDiagnosticDouble(focus_scale)
                    << ", runtimeMaxClampMask=" << FormatHex(runtime_max_clamp_mask);
@@ -2255,6 +2308,8 @@ XrResult OpenXrLayer::EnumerateViewConfigurationViews(XrInstance instance,
                        << ", runtimeSamples=" << diagnostic.recommended_sample_count << "/"
                        << diagnostic.max_sample_count
                        << ", foveatedRequest=" << foveated_state
+                       << ", vectorFoveatedRequestInjected="
+                       << (diagnostic.vector_foveated_request_injected ? 1 : 0)
                        << ", vectorRequested=" << diagnostic.vector_requested_width << "x"
                        << diagnostic.vector_requested_height << "@x"
                        << FormatDiagnosticDouble(diagnostic.requested_scale)
@@ -5249,6 +5304,13 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         IsQuadViewsEmulationActive() && has_active_primary_view_configuration_ &&
         IsQuadViewConfiguration(active_primary_view_configuration_type_) &&
         active_runtime_view_configuration_type_ == XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    if (quadviews_compositor_recovery_pending_ && quadviews_projection_split_active) {
+        RecycleD3D11QuadViewsCompositionTargets();
+        quadviews_compositor_recovery_pending_ = false;
+        pending_quadviews_compositor_diagnostics_ =
+            std::max<uint32_t>(pending_quadviews_compositor_diagnostics_, 120);
+        logger_.Info("Quadviews compositor output targets recycled after eye-gaze tracking recovered.");
+    }
     // Varjo compatible quadviews: the focus sharpen runs inside the projection
     // rewrite loop below, so a requested sharpen must keep this frame out of the
     // identity-delta fast path — otherwise sharpening only ever ran on frames
@@ -6601,6 +6663,10 @@ void OpenXrLayer::ResetSessionState() {
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
     quadviews_last_valid_gaze_wall_time_.reset();
+    quadviews_eye_gaze_loss_started_wall_time_.reset();
+    quadviews_eye_gaze_loss_was_locate_failure_ = false;
+    quadviews_has_seen_valid_gaze_ = false;
+    quadviews_compositor_recovery_pending_ = false;
     active_primary_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     active_runtime_view_configuration_type_ = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     has_active_primary_view_configuration_ = false;
@@ -6793,6 +6859,10 @@ void OpenXrLayer::DestroyEyeGazeResources() {
     quadviews_smoothed_focus_pitch_radians_ = 0.0;
     quadviews_last_focus_smoothing_wall_time_.reset();
     quadviews_last_valid_gaze_wall_time_.reset();
+    quadviews_eye_gaze_loss_started_wall_time_.reset();
+    quadviews_eye_gaze_loss_was_locate_failure_ = false;
+    quadviews_has_seen_valid_gaze_ = false;
+    quadviews_compositor_recovery_pending_ = false;
     last_eye_gaze_self_sync_time_.reset();
 
     if (eye_gaze_space != XR_NULL_HANDLE && next_destroy_space_) {
@@ -6853,7 +6923,14 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
         return "path#" + std::to_string(static_cast<uint64_t>(state.interactionProfile));
     };
 
-    auto log_eye_gaze_diagnostic = [&](const std::string& reason) {
+    auto log_eye_gaze_diagnostic = [&](const std::string& reason, bool locate_failure = false) {
+        if (settings.tracking_mode == QuadViewsTrackingMode::Eye && quadviews_has_seen_valid_gaze_ &&
+            !quadviews_eye_gaze_loss_started_wall_time_.has_value()) {
+            quadviews_eye_gaze_loss_started_wall_time_ = std::chrono::steady_clock::now();
+        }
+        if (locate_failure && quadviews_eye_gaze_loss_started_wall_time_.has_value()) {
+            quadviews_eye_gaze_loss_was_locate_failure_ = true;
+        }
         if (settings.tracking_mode == QuadViewsTrackingMode::Eye && !has_logged_eye_gaze_focus_unavailable_) {
             // Debounce: require the gaze to stay unavailable for several frames
             // before declaring it lost, so a single-frame dropout (a blink) does
@@ -6885,6 +6962,10 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
     };
 
     if (settings.tracking_mode != QuadViewsTrackingMode::Eye) {
+        quadviews_eye_gaze_loss_started_wall_time_.reset();
+        quadviews_eye_gaze_loss_was_locate_failure_ = false;
+        quadviews_has_seen_valid_gaze_ = false;
+        quadviews_compositor_recovery_pending_ = false;
         return false;
     }
     if (session != active_session_) {
@@ -6951,7 +7032,7 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
         (gaze_location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) == 0) {
         log_eye_gaze_diagnostic("gaze space locate failed, result=" +
                                 FormatHex(static_cast<uint64_t>(locate_result)) +
-                                ", flags=" + FormatHex(static_cast<uint64_t>(gaze_location.locationFlags)));
+                                ", flags=" + FormatHex(static_cast<uint64_t>(gaze_location.locationFlags)), true);
         return false;
     }
 
@@ -6976,6 +7057,20 @@ bool OpenXrLayer::LocateEyeGazeFocusOffsets(XrSession session,
     }
 
     const auto now = std::chrono::steady_clock::now();
+    if (quadviews_eye_gaze_loss_started_wall_time_.has_value()) {
+        const auto gaze_loss_duration = now - *quadviews_eye_gaze_loss_started_wall_time_;
+        if (quadviews_has_seen_valid_gaze_ && quadviews_eye_gaze_loss_was_locate_failure_ &&
+            gaze_loss_duration >= std::chrono::seconds(2)) {
+            const auto gaze_loss_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(gaze_loss_duration).count();
+            quadviews_compositor_recovery_pending_ = true;
+            logger_.Info("Quadviews eye-gaze tracking recovered after " + std::to_string(gaze_loss_ms) +
+                         " ms; scheduling compositor output target recycle.");
+        }
+        quadviews_eye_gaze_loss_started_wall_time_.reset();
+        quadviews_eye_gaze_loss_was_locate_failure_ = false;
+    }
+    quadviews_has_seen_valid_gaze_ = true;
     quadviews_last_valid_gaze_wall_time_ = now;
     double delta_seconds = 0.0;
     if (quadviews_last_focus_smoothing_wall_time_.has_value()) {
@@ -7323,6 +7418,7 @@ bool OpenXrLayer::IsTrackedViewSpace(XrSpace space) const {
 }
 
 void OpenXrLayer::RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* view_locate_info,
+                                                     bool vector_request_injected,
                                                      const XrViewState* view_state,
                                                      XrResult result,
                                                      uint32_t view_capacity_input,
@@ -7343,6 +7439,9 @@ void OpenXrLayer::RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* vie
     VarjoNativeFoveationDiagnosticState& diagnostic = varjo_native_foveation_diagnostic_;
     ++diagnostic.locate_calls;
     ++diagnostic.request_state_counts[request_state];
+    if (vector_request_injected) {
+        ++diagnostic.vector_injected_locate_requests;
+    }
 
     const uint8_t request_state_bit = static_cast<uint8_t>(uint8_t{1} << request_state);
     if ((diagnostic.logged_request_state_mask & request_state_bit) == 0) {
@@ -7350,6 +7449,7 @@ void OpenXrLayer::RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* vie
         std::ostringstream stream;
         stream << "Native Varjo foveated locate contract: locateCall=" << diagnostic.locate_calls
                << ", requestChainPresent=" << (request_present ? 1 : 0)
+               << ", vectorRequestInjected=" << (vector_request_injected ? 1 : 0)
                << ", foveatedRenderingActive=" << (request_active ? 1 : 0)
                << ", displayTime=" << (view_locate_info ? view_locate_info->displayTime : 0)
                << ", result=" << FormatHex(static_cast<uint64_t>(result))
@@ -7420,6 +7520,7 @@ void OpenXrLayer::RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* vie
         std::ostringstream stream;
         stream << "Native Varjo focus FOV movement observed after " << diagnostic.successful_quad_locates
                << " successful quad locates: requestChainPresent=" << (request_present ? 1 : 0)
+               << ", vectorRequestInjected=" << (vector_request_injected ? 1 : 0)
                << ", foveatedRenderingActive=" << (request_active ? 1 : 0)
                << ", initialFocusView2=" << FormatFov(diagnostic.initial_focus_fovs[0])
                << ", currentFocusView2=" << FormatFov(views[2].fov)
@@ -7453,6 +7554,7 @@ void OpenXrLayer::LogVarjoNativeFoveationSummaryLocked(std::string_view reason, 
            << ", requestAbsent=" << diagnostic.request_state_counts[0]
            << ", requestPresentInactive=" << diagnostic.request_state_counts[1]
            << ", requestPresentActive=" << diagnostic.request_state_counts[2]
+           << ", vectorInjectedLocateRequests=" << diagnostic.vector_injected_locate_requests
            << ", successfulQuadLocates=" << diagnostic.successful_quad_locates
            << ", focusFovObserved=" << (diagnostic.focus_ranges_initialized ? 1 : 0)
            << ", focusFovMotionObserved=" << (diagnostic.focus_motion_logged ? 1 : 0);
@@ -7495,6 +7597,7 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
 
     bool quadviews_emulation_active = false;
     bool varjo_compatible = false;
+    bool request_native_foveated_locates = false;
     QuadViewsResolvedSettings quadviews_settings;
     {
         std::scoped_lock lock(mutex_);
@@ -7503,18 +7606,37 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
         quadviews_emulation_active = IsQuadViewsEmulationActive();
         varjo_compatible = varjo_compatible_quadviews_active_;
         quadviews_settings = resolved_settings_.quadviews;
+        request_native_foveated_locates =
+            IsQuadViewsActive() && varjo_foveated_rendering_extension_requested_ &&
+            quadviews_settings.tracking_mode == QuadViewsTrackingMode::Eye;
     }
 
     // Varjo compatible mode: forward the app's quad locate untouched — including the
     // Varjo foveated-rendering next chain, which the runtime consumes to place the
     // focus inset by gaze — and return the runtime's real 4 views. No stereo remap,
     // no synthesis. Pivot is still applied downstream in LocateViews.
+    // The one exception to transparent forwarding is supplying a missing
+    // foveated-rendering request while VectorXR eye tracking is active.
     if (varjo_compatible && view_locate_info &&
         IsQuadViewConfiguration(view_locate_info->viewConfigurationType)) {
+        XrViewLocateInfo native_locate_info = *view_locate_info;
+        XrViewLocateFoveatedRenderingVARJO injected_foveated_request{
+            XR_TYPE_VIEW_LOCATE_FOVEATED_RENDERING_VARJO};
+        const XrViewLocateInfo* native_view_locate_info = view_locate_info;
+        bool vector_request_injected = false;
+        if (request_native_foveated_locates &&
+            !FindStructInChain(view_locate_info->next, XR_TYPE_VIEW_LOCATE_FOVEATED_RENDERING_VARJO)) {
+            injected_foveated_request.next = view_locate_info->next;
+            injected_foveated_request.foveatedRenderingActive = XR_TRUE;
+            native_locate_info.next = &injected_foveated_request;
+            native_view_locate_info = &native_locate_info;
+            vector_request_injected = true;
+        }
         const XrResult native_result = next_locate_views_(
-            session, view_locate_info, view_state, view_capacity_input, view_count_output, views);
+            session, native_view_locate_info, view_state, view_capacity_input, view_count_output, views);
         RecordVarjoNativeLocateDiagnostics(
-            view_locate_info, view_state, native_result, view_capacity_input, view_count_output, views);
+            native_view_locate_info, vector_request_injected, view_state, native_result, view_capacity_input,
+            view_count_output, views);
         return native_result;
     }
 
@@ -8560,6 +8682,32 @@ void OpenXrLayer::SharpenNativeFocusViews(std::vector<XrCompositionLayerProjecti
             d3d11_focus_sharpen_.has_logged_skipped = true;
         }
     }
+}
+
+void OpenXrLayer::RecycleD3D11QuadViewsCompositionTargets() {
+    for (QuadViewsCompositionTarget& target : d3d11_quadviews_compositor_.targets) {
+        SafeReleaseVector(target.image_render_target_views);
+        SafeRelease(target.render_target_view);
+        SafeRelease(target.render_texture);
+        if (target.swapchain != XR_NULL_HANDLE && next_destroy_swapchain_) {
+            next_destroy_swapchain_(target.swapchain);
+        }
+        target = {};
+    }
+
+    // A query issued before the headset session break may never become
+    // readable. Preserve the device-level query objects but discard their
+    // pending state along with the runtime-owned output swapchains.
+    for (QuadViewsGpuTimingQuery& query : d3d11_quadviews_compositor_.gpu_timing_queries) {
+        query.issued = false;
+        query.frame_time = 0;
+    }
+    d3d11_quadviews_compositor_.has_logged_prewarm = false;
+    d3d11_quadviews_compositor_.has_last_completed_gpu_timing = false;
+    d3d11_quadviews_compositor_.failure_logs_remaining = 8;
+    d3d11_quadviews_compositor_.next_gpu_timing_query = 0;
+    d3d11_quadviews_compositor_.last_completed_gpu_ms = 0.0;
+    d3d11_quadviews_compositor_.last_completed_gpu_frame_time = 0;
 }
 
 void OpenXrLayer::ResetD3D11QuadViewsCompositor() {

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -20,6 +20,7 @@
 #include "depthxr/effects.h"
 #include "depthxr/input_devices.h"
 #include "depthxr/process_info.h"
+#include "depthxr/quadviews_sizing.h"
 #include "depthxr/runtime_compatibility.h"
 #include "depthxr/runtime_pacing.h"
 #include "depthxr/seen_apps.h"
@@ -140,17 +141,6 @@ double QuadViewsFocusWidthScale(const QuadViewsResolvedSettings& settings) {
 
 double QuadViewsFocusHeightScale(const QuadViewsResolvedSettings& settings) {
     return settings.focus_scale * Clamp(settings.focus_vertical_size_percent, 1.0, 100.0) / 100.0;
-}
-
-// Density multiplier for the full-FOV composite canvas relative to the runtime's
-// stereo-recommended resolution. The focus view is rendered at focus_scale x its
-// FOV fraction of stereo; for the focus texture to sample 1:1 into its sub-rectangle
-// of the canvas (rather than being downsampled back to stereo-native, which throws
-// away the whole point of a high-density inset), the canvas must span the full FOV
-// at focus_scale density. Never drop below 1.0 so the submitted layer keeps at least
-// stereo-native quality. This mirrors OpenXR-Quad-Views-Foveated's focus_multiplier.
-double QuadViewsCanvasDensity(const QuadViewsResolvedSettings& settings) {
-    return std::max(1.0, settings.focus_scale);
 }
 
 uint32_t EstimateFullResolutionDimension(uint32_t rendered_dimension, double render_scale) {
@@ -3143,17 +3133,22 @@ void OpenXrLayer::TryPrewarmD3D11QuadViewsCompositor() {
         }
     }
 
-    const bool output_ready = EnsureD3D11QuadViewsCompositor(nullptr,
-                                                            cached_quadviews_stereo_recommended_width_,
-                                                            cached_quadviews_stereo_recommended_height_,
-                                                            largest_swapchain->format);
+    const QuadViewsCanvasDimensions canvas_dimensions = ComputeQuadViewsCanvasDimensions(
+        cached_quadviews_stereo_recommended_width_,
+        cached_quadviews_stereo_recommended_height_,
+        cached_quadviews_stereo_max_width_,
+        cached_quadviews_stereo_max_height_,
+        resolved_settings_.quadviews.focus_scale);
+    const bool output_ready = EnsureD3D11QuadViewsCompositor(
+        nullptr, canvas_dimensions.width, canvas_dimensions.height, largest_swapchain->format);
     if (output_ready && !d3d11_quadviews_compositor_.has_logged_prewarm) {
         const uint32_t direct_output_count =
             static_cast<uint32_t>(d3d11_quadviews_compositor_.targets[0].image_render_target_views.empty() ? 0 : 1) +
             static_cast<uint32_t>(d3d11_quadviews_compositor_.targets[1].image_render_target_views.empty() ? 0 : 1);
         logger_.Info("D3D11 quadviews compositor prewarmed: outputSize=" +
-                     std::to_string(cached_quadviews_stereo_recommended_width_) + "x" +
-                     std::to_string(cached_quadviews_stereo_recommended_height_) +
+                     std::to_string(canvas_dimensions.width) + "x" +
+                     std::to_string(canvas_dimensions.height) +
+                     ", canvasDensity=" + FormatDiagnosticDouble(canvas_dimensions.density) +
                      ", directInputSwapchains=" + std::to_string(direct_input_count) + "/4" +
                      ", directOutputEyes=" + std::to_string(direct_output_count) + "/2" +
                      ", gpuTiming=" + std::to_string(d3d11_quadviews_compositor_.gpu_timing_available));
@@ -3195,7 +3190,6 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
     const double peripheral_scale = resolved_settings_.quadviews.peripheral_scale;
     const double focus_width_scale = QuadViewsFocusWidthScale(resolved_settings_.quadviews);
     const double focus_height_scale = QuadViewsFocusHeightScale(resolved_settings_.quadviews);
-    const double canvas_density = QuadViewsCanvasDensity(resolved_settings_.quadviews);
 
     // Reconstruct the runtime's stereo-native full-FOV resolution (preferring the value
     // cached during xrEnumerateViewConfigurationViews), then scale it by the focus density
@@ -3218,12 +3212,15 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
             EstimateFullResolutionDimension(swapchains[3]->height, focus_height_scale),
         });
     }
-    const uint32_t canvas_max_width =
-        cached_quadviews_stereo_max_width_ > 0 ? cached_quadviews_stereo_max_width_ : stereo_full_width * 4;
-    const uint32_t canvas_max_height =
-        cached_quadviews_stereo_max_height_ > 0 ? cached_quadviews_stereo_max_height_ : stereo_full_height * 4;
-    const uint32_t output_width = ScaleDimension(stereo_full_width, canvas_density, canvas_max_width);
-    const uint32_t output_height = ScaleDimension(stereo_full_height, canvas_density, canvas_max_height);
+    const QuadViewsCanvasDimensions canvas_dimensions = ComputeQuadViewsCanvasDimensions(
+        stereo_full_width,
+        stereo_full_height,
+        cached_quadviews_stereo_max_width_,
+        cached_quadviews_stereo_max_height_,
+        resolved_settings_.quadviews.focus_scale);
+    const double canvas_density = canvas_dimensions.density;
+    const uint32_t output_width = canvas_dimensions.width;
+    const uint32_t output_height = canvas_dimensions.height;
     const int64_t output_format = swapchains[2]->format;
     if (!EnsureD3D11QuadViewsCompositor(source_layer, output_width, output_height, output_format)) {
         return false;

--- a/layer/src/quadviews_sizing.cpp
+++ b/layer/src/quadviews_sizing.cpp
@@ -1,0 +1,42 @@
+#include "depthxr/quadviews_sizing.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace depthxr {
+namespace {
+
+uint32_t FallbackCanvasMaximum(uint32_t stereo_dimension) {
+    constexpr uint32_t kFallbackScale = 4;
+    if (stereo_dimension > std::numeric_limits<uint32_t>::max() / kFallbackScale) {
+        return std::numeric_limits<uint32_t>::max();
+    }
+    return std::max<uint32_t>(1, stereo_dimension * kFallbackScale);
+}
+
+uint32_t ScaleCanvasDimension(uint32_t stereo_dimension, double density, uint32_t runtime_maximum) {
+    const double scaled = std::max(1.0, std::round(static_cast<double>(stereo_dimension) * density));
+    const uint32_t maximum = runtime_maximum > 0 ? runtime_maximum : FallbackCanvasMaximum(stereo_dimension);
+    return static_cast<uint32_t>(std::min<double>(scaled, std::max<uint32_t>(1, maximum)));
+}
+
+} // namespace
+
+QuadViewsCanvasDimensions ComputeQuadViewsCanvasDimensions(uint32_t stereo_width,
+                                                           uint32_t stereo_height,
+                                                           uint32_t runtime_max_width,
+                                                           uint32_t runtime_max_height,
+                                                           double focus_scale) {
+    // Match the focus texture's density across the full-FOV output so its
+    // sub-rectangle remains a 1:1 sample. Never submit below the runtime's
+    // stereo-native density.
+    const double density = std::max(1.0, focus_scale);
+    return {
+        ScaleCanvasDimension(stereo_width, density, runtime_max_width),
+        ScaleCanvasDimension(stereo_height, density, runtime_max_height),
+        density,
+    };
+}
+
+} // namespace depthxr

--- a/layer/tests/config_tests.cpp
+++ b/layer/tests/config_tests.cpp
@@ -9,6 +9,7 @@
 #include "depthxr/config_parser.h"
 #include "depthxr/effects.h"
 #include "depthxr/logger.h"
+#include "depthxr/quadviews_sizing.h"
 #include "depthxr/runtime_pacing.h"
 #include "depthxr/runtime_compatibility.h"
 #include "depthxr/seen_apps.h"
@@ -1723,6 +1724,30 @@ void TestTurboSteamVrQuadviewsCompatibilityPolicy() {
            "The DCS compatibility rule must not disable Turbo globally");
 }
 
+void TestQuadViewsCanvasDimensionsMatchCompositionDensity() {
+    const depthxr::QuadViewsCanvasDimensions supersampled =
+        depthxr::ComputeQuadViewsCanvasDimensions(6240, 6280, 16384, 16384, 1.1);
+    Expect(supersampled.width == 6864 && supersampled.height == 6908,
+           "Quadviews prewarm dimensions did not match the density-scaled composition canvas");
+    Expect(std::abs(supersampled.density - 1.1) < 0.0001,
+           "Quadviews canvas density did not retain focus supersampling");
+
+    const depthxr::QuadViewsCanvasDimensions fallback_maximum =
+        depthxr::ComputeQuadViewsCanvasDimensions(6240, 6280, 0, 0, 1.1);
+    Expect(fallback_maximum.width == 6864 && fallback_maximum.height == 6908,
+           "Quadviews canvas fallback maximum unexpectedly clamped the scaled dimensions");
+
+    const depthxr::QuadViewsCanvasDimensions native =
+        depthxr::ComputeQuadViewsCanvasDimensions(6240, 6280, 16384, 16384, 0.8);
+    Expect(native.width == 6240 && native.height == 6280 && std::abs(native.density - 1.0) < 0.0001,
+           "Quadviews canvas dropped below runtime-native density");
+
+    const depthxr::QuadViewsCanvasDimensions clamped =
+        depthxr::ComputeQuadViewsCanvasDimensions(1000, 900, 1050, 920, 1.2);
+    Expect(clamped.width == 1050 && clamped.height == 920,
+           "Quadviews canvas dimensions exceeded the runtime maximum");
+}
+
 void TestSwapchainImageQueuePreservesFifo() {
     depthxr::SwapchainImageQueue queue;
     queue.Acquire(2);
@@ -1781,6 +1806,7 @@ int main() {
     TestLoggerCollapsesDuplicateMessages();
     TestEyeGazeExtensionCompatibilityPolicy();
     TestTurboSteamVrQuadviewsCompatibilityPolicy();
+    TestQuadViewsCanvasDimensionsMatchCompositionDensity();
 #ifdef _WIN32
     TestD3D11SharpenShaderRegression();
 #endif


### PR DESCRIPTION
Restores gaze-driven rendering after Virtual Desktop reconnects, activates native Varjo foveation when DCS omits its request, and fixes inactive-layer and Quadviews prewarm paths that could disrupt frame pacing.