### PR TITLE
Prepare signed v0.16.1 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /app
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: /app/src-tauri
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  app:
+    name: App tests and build
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout pinned vcpkg registry
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: microsoft/vcpkg
+          ref: aae277acf4e7de287ddb5e208b5316614de6aad7
+          path: .vcpkg
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.94.1
+
+      - name: Install OpenXR loader
+        shell: pwsh
+        run: |
+          $vcpkgRoot = Join-Path $env:GITHUB_WORKSPACE ".vcpkg"
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to bootstrap the pinned vcpkg registry."
+          }
+
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $env:VCPKG_ROOT = $vcpkgRoot
+          & "$vcpkgRoot\vcpkg.exe" install openxr-loader:x64-windows
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install the pinned OpenXR loader dependency."
+          }
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Test app model
+        working-directory: app
+        run: npm test
+
+      - name: Build app frontend
+        working-directory: app
+        run: npm run build
+
+      - name: Build and test OpenXR layer
+        shell: pwsh
+        run: |
+          ./scripts/Build-Layer.ps1
+          ./scripts/Stage-ReleasePayload.ps1
+
+      - name: Check Tauri app
+        working-directory: app/src-tauri
+        run: cargo check --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Checkout pinned vcpkg registry
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: microsoft/vcpkg
           ref: aae277acf4e7de287ddb5e208b5316614de6aad7
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,38 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"
 
 permissions:
   contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   windows-installer:
     name: Build Windows installer
     runs-on: windows-2022
+    environment: release
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tagged commit belongs to master
+        shell: pwsh
+        run: |
+          git merge-base --is-ancestor $env:GITHUB_SHA refs/remotes/origin/master
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release tag must point to a commit contained in master."
+          }
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -28,6 +45,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Verify tag matches app versions
+        if: github.event_name == 'push'
         shell: pwsh
         run: ./scripts/Assert-VersionMatchesTag.ps1 -TagName "${{ github.ref_name }}"
 
@@ -50,11 +68,125 @@ jobs:
           $env:VCPKG_ROOT = $vcpkgRoot
           & "$vcpkgRoot\vcpkg.exe" install openxr-loader:x64-windows
 
-      - name: Build installer
+      - name: Build and stage OpenXR layer
+        shell: pwsh
+        run: |
+          ./scripts/Build-Layer.ps1
+          ./scripts/Stage-ReleasePayload.ps1
+
+      - name: Build VectorXR app without installer
         working-directory: app
-        run: npm run installer:build
+        run: npm run tauri:build -- --no-bundle
+
+      - name: Validate signing configuration
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_SIGNING_ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+        run: |
+          $required = @(
+            "AZURE_CLIENT_ID",
+            "AZURE_TENANT_ID",
+            "AZURE_SUBSCRIPTION_ID",
+            "AZURE_SIGNING_ENDPOINT",
+            "AZURE_SIGNING_ACCOUNT",
+            "AZURE_CERTIFICATE_PROFILE"
+          )
+
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+              throw "Required release-environment variable '$name' is not configured."
+            }
+          }
+
+      - name: Log in to Azure with GitHub OIDC
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign VectorXR app and OpenXR layer
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+          files: |
+            ${{ github.workspace }}\app\src-tauri\target\release\vectorxr-app.exe
+            ${{ github.workspace }}\app\src-tauri\resources\vectorxr-layer\XR_APILAYER_DIENERTECH_VECTORXR.dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: VectorXR
+          description-url: https://github.com/DienerTech/vectorxr
+
+      - name: Verify signed app payload
+        shell: pwsh
+        run: |
+          $files = @(
+            "app/src-tauri/target/release/vectorxr-app.exe",
+            "app/src-tauri/resources/vectorxr-layer/XR_APILAYER_DIENERTECH_VECTORXR.dll"
+          )
+
+          foreach ($file in $files) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $file
+            Write-Host "$file : $($signature.Status) : $($signature.SignerCertificate.Subject)"
+            if ($signature.Status -ne "Valid") {
+              throw "Invalid Authenticode signature for '$file': $($signature.Status)."
+            }
+          }
+
+      - name: Build NSIS installer
+        working-directory: app
+        run: npm run tauri:bundle -- --bundles nsis
+
+      - name: Sign NSIS installer
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+          files-folder: ${{ github.workspace }}\app\src-tauri\target\release\bundle\nsis
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: VectorXR Setup
+          description-url: https://github.com/DienerTech/vectorxr
+
+      - name: Verify signed installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path "app/src-tauri/target/release/bundle/nsis" -Filter "*.exe")
+          if ($installers.Count -ne 1) {
+            throw "Expected exactly one NSIS installer, found $($installers.Count)."
+          }
+
+          $signature = Get-AuthenticodeSignature -LiteralPath $installers[0].FullName
+          Write-Host "$($installers[0].Name) : $($signature.Status) : $($signature.SignerCertificate.Subject)"
+          if ($signature.Status -ne "Valid") {
+            throw "Invalid Authenticode signature for '$($installers[0].Name)': $($signature.Status)."
+          }
+
+      - name: Upload signing smoke-test artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: VectorXR-signing-smoke-${{ github.sha }}
+          path: |
+            app/src-tauri/target/release/vectorxr-app.exe
+            app/src-tauri/resources/vectorxr-layer/XR_APILAYER_DIENERTECH_VECTORXR.dll
+            app/src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Prepare release assets
+        if: github.event_name == 'push'
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}"
@@ -75,6 +207,7 @@ jobs:
           "$($hash.Hash.ToLowerInvariant())  $installerName" | Set-Content -LiteralPath "$installerPath.sha256" -Encoding ascii
 
       - name: Publish GitHub release
+        if: github.event_name == 'push'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout pinned vcpkg registry
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: microsoft/vcpkg
           ref: aae277acf4e7de287ddb5e208b5316614de6aad7
@@ -46,7 +46,7 @@ jobs:
           }
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload signing smoke-test artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: VectorXR-signing-smoke-${{ github.sha }}
           path: |
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload signed release payload
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: VectorXR-release-${{ github.sha }}
           path: release-assets
@@ -268,7 +268,7 @@ jobs:
 
     steps:
       - name: Download signed release payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: VectorXR-release-${{ github.sha }}
           path: release-assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,12 +18,24 @@ jobs:
     name: Build Windows installer
     runs-on: windows-2022
     environment: release
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout pinned vcpkg registry
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: microsoft/vcpkg
+          ref: aae277acf4e7de287ddb5e208b5316614de6aad7
+          path: .vcpkg
+          persist-credentials: false
 
       - name: Verify tagged commit belongs to master
         shell: pwsh
@@ -35,14 +46,16 @@ jobs:
           }
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: app/package-lock.json
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.94.1
 
       - name: Verify tag matches app versions
         if: github.event_name == 'push'
@@ -60,13 +73,18 @@ jobs:
       - name: Install OpenXR loader
         shell: pwsh
         run: |
-          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
-          if (-not $vcpkgRoot) {
-            $vcpkgRoot = "C:\vcpkg"
+          $vcpkgRoot = Join-Path $env:GITHUB_WORKSPACE ".vcpkg"
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to bootstrap the pinned vcpkg registry."
           }
 
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           $env:VCPKG_ROOT = $vcpkgRoot
           & "$vcpkgRoot\vcpkg.exe" install openxr-loader:x64-windows
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install the pinned OpenXR loader dependency."
+          }
 
       - name: Build and stage OpenXR layer
         shell: pwsh
@@ -104,14 +122,14 @@ jobs:
           }
 
       - name: Log in to Azure with GitHub OIDC
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign VectorXR app and OpenXR layer
-        uses: azure/artifact-signing-action@v2
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         with:
           endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
@@ -139,6 +157,15 @@ jobs:
             if ($signature.Status -ne "Valid") {
               throw "Invalid Authenticode signature for '$file': $($signature.Status)."
             }
+
+            if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|$)' -or
+                $signature.SignerCertificate.Subject -notmatch '(^|,\s*)O=DienerTech LLC(,|$)') {
+              throw "Unexpected Authenticode publisher for '$file': $($signature.SignerCertificate.Subject)."
+            }
+
+            if (-not $signature.TimeStamperCertificate) {
+              throw "The Authenticode signature for '$file' does not contain a trusted timestamp."
+            }
           }
 
       - name: Build NSIS installer
@@ -146,7 +173,7 @@ jobs:
         run: npm run tauri:bundle -- --bundles nsis
 
       - name: Sign NSIS installer
-        uses: azure/artifact-signing-action@v2
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         with:
           endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
@@ -173,9 +200,18 @@ jobs:
             throw "Invalid Authenticode signature for '$($installers[0].Name)': $($signature.Status)."
           }
 
+          if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|$)' -or
+              $signature.SignerCertificate.Subject -notmatch '(^|,\s*)O=DienerTech LLC(,|$)') {
+            throw "Unexpected Authenticode publisher for '$($installers[0].Name)': $($signature.SignerCertificate.Subject)."
+          }
+
+          if (-not $signature.TimeStamperCertificate) {
+            throw "The Authenticode signature for '$($installers[0].Name)' does not contain a trusted timestamp."
+          }
+
       - name: Upload signing smoke-test artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: VectorXR-signing-smoke-${{ github.sha }}
           path: |
@@ -206,35 +242,55 @@ jobs:
           $hash = Get-FileHash -LiteralPath $installerPath -Algorithm SHA256
           "$($hash.Hash.ToLowerInvariant())  $installerName" | Set-Content -LiteralPath "$installerPath.sha256" -Encoding ascii
 
-      - name: Publish GitHub release
-        if: github.event_name == 'push'
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          $tag = "${{ github.ref_name }}"
           $notesPath = Join-Path $env:GITHUB_WORKSPACE "release/notes/$tag.md"
           if (-not (Test-Path -LiteralPath $notesPath -PathType Leaf)) {
             throw "Release notes were not found at $notesPath."
           }
 
-          $assets = Get-ChildItem -Path "release-assets" -File | ForEach-Object { $_.FullName }
+          Copy-Item -LiteralPath $notesPath -Destination (Join-Path $releaseDir "release-notes.md")
+
+      - name: Upload signed release payload
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: VectorXR-release-${{ github.sha }}
+          path: release-assets
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-release:
+    name: Publish GitHub release
+    if: github.event_name == 'push'
+    needs: windows-installer
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download signed release payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: VectorXR-release-${{ github.sha }}
+          path: release-assets
+
+      - name: Publish immutable GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $notesPath = Join-Path $env:GITHUB_WORKSPACE "release-assets/release-notes.md"
+
           gh release view $tag *> $null
-          $releaseExists = $LASTEXITCODE -eq 0
+          if ($LASTEXITCODE -eq 0) {
+            throw "Release $tag already exists; refusing to replace its metadata or assets."
+          }
 
-          if ($releaseExists) {
-            gh release edit $tag --title "VectorXR $tag" --notes-file $notesPath
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to update release metadata for $tag."
-            }
+          $assets = Get-ChildItem -Path "release-assets" -File |
+            Where-Object { $_.Name -ne "release-notes.md" } |
+            ForEach-Object { $_.FullName }
 
-            gh release upload $tag @assets --clobber
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to upload release assets for $tag."
-            }
-          } else {
-            gh release create $tag @assets --verify-tag --title "VectorXR $tag" --notes-file $notesPath
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to create release $tag."
-            }
+          gh release create $tag @assets --verify-tag --title "VectorXR $tag" --notes-file $notesPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create release $tag."
           }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {
@@ -12,6 +12,7 @@
     "icons:generate": "powershell -ExecutionPolicy Bypass -File ../scripts/Generate-TauriIcons.ps1",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "tauri:bundle": "tauri bundle",
     "installer:build": "powershell -ExecutionPolicy Bypass -File ../scripts/Build-Installer.ps1"
   },
   "dependencies": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.16.0"
+version = "0.16.1"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/lib/patchNotes.json
+++ b/app/src/lib/patchNotes.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "0.16.1",
+    "date": "2026-08-11",
+    "title": "Signed Windows Releases",
+    "summary": "Adds verified DienerTech code signatures to VectorXR's Windows application, OpenXR layer, and installer.",
+    "items": [
+      {
+        "html": "<strong>Verified Windows publisher</strong>",
+        "items": [
+          "Signs the VectorXR configuration application and OpenXR API layer DLL as DienerTech LLC using Azure Artifact Signing.",
+          "Signs the final NSIS installer after it contains the signed application and layer payload.",
+          "Applies RFC 3161 timestamps so Windows can continue validating each signature after its short-lived signing certificate rotates."
+        ]
+      },
+      {
+        "html": "<strong>Protected release pipeline</strong>",
+        "items": [
+          "Uses passwordless GitHub workload identity federation, keeping private signing keys and reusable Azure credentials out of the repository.",
+          "Restricts signing authority to the VectorXR certificate profile and release environment.",
+          "Verifies every Authenticode signature before generating checksums or publishing release assets, and rejects release tags outside the master branch history."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.16.0",
     "date": "2026-08-06",
     "title": "Snap Views, Nudges, and Quadviews Diagnostics",

--- a/app/tests/patchNotes.test.mjs
+++ b/app/tests/patchNotes.test.mjs
@@ -44,10 +44,10 @@ test('legacy and current patch notes use organized nested sections', () => {
     assert.ok(entry.items.every((item) => typeof item !== 'string'), `${entry.version} has an ungrouped top-level item`)
   }
 
-  assert.equal(patchNotes[0].version, '0.16.0')
-  assert.equal(patchNotes[0].title, 'Snap Views, Nudges, and Quadviews Diagnostics')
-  assert.match(patchNotes[0].summary, /Pivot/)
-  assert.match(JSON.stringify(patchNotes[0].items), /Quadviews/)
+  assert.equal(patchNotes[0].version, '0.16.1')
+  assert.equal(patchNotes[0].title, 'Signed Windows Releases')
+  assert.match(patchNotes[0].summary, /signatures/)
+  assert.match(JSON.stringify(patchNotes[0].items), /OpenXR API layer/)
   const maxDepth = Math.max(
     ...patchNotes[0].items.map((item, index) => assertItem(item, `latest.items[${index}]`)),
   )

--- a/release/notes/v0.16.1.md
+++ b/release/notes/v0.16.1.md
@@ -1,0 +1,14 @@
+## Signed Windows Releases
+
+Adds verified DienerTech code signatures to VectorXR's Windows application, OpenXR layer, and installer.
+
+### Changes
+
+- <strong>Verified Windows publisher</strong>
+  - Signs the VectorXR configuration application and OpenXR API layer DLL as DienerTech LLC using Azure Artifact Signing.
+  - Signs the final NSIS installer after it contains the signed application and layer payload.
+  - Applies RFC 3161 timestamps so Windows can continue validating each signature after its short-lived signing certificate rotates.
+- <strong>Protected release pipeline</strong>
+  - Uses passwordless GitHub workload identity federation, keeping private signing keys and reusable Azure credentials out of the repository.
+  - Restricts signing authority to the VectorXR certificate profile and release environment.
+  - Verifies every Authenticode signature before generating checksums or publishing release assets, and rejects release tags outside the master branch history.


### PR DESCRIPTION
## Summary

- sign the VectorXR app executable and OpenXR layer DLL with the DienerTech LLC Azure Artifact Signing profile before bundling
- sign and verify the final NSIS installer before checksums or release publication
- authenticate GitHub Actions to Azure through passwordless OIDC with profile-scoped signing authority
- add a manual, non-publishing signing smoke test that uploads signed artifacts for seven days
- prepare the 0.16.1 version bump, in-app patch notes, lockfiles, and GitHub release notes
- harden the release supply chain with immutable action SHAs, pinned Rust/vcpkg inputs, and non-persisted checkout credentials
- separate Azure signing permission from GitHub release-write permission
- require the expected DienerTech publisher and a trusted timestamp on signed binaries
- refuse to overwrite an existing release or its assets
- add read-only PR CI and weekly Dependabot updates for Actions, npm, and Cargo

## Why

VectorXR currently distributes unsigned Windows binaries. This adds verified Authenticode signatures to every signable VectorXR artifact while keeping private keys and reusable Azure credentials outside GitHub. The JSON OpenXR manifest is data rather than a PE binary; Windows verifies the signed layer DLL referenced by that manifest.

The hardened workflow minimizes the authority available to each job. The Windows build job can request the Azure signing identity but cannot modify repository contents; the tag-only publishing job can create a GitHub Release but cannot request an Azure identity.

## Release safety

Manual workflow runs build, sign, verify, and upload smoke-test artifacts but cannot create or edit a GitHub Release. Only a matching version-tag push can prepare and publish release assets, and the tag must point to a commit contained in `master`.

Live repository controls now require full-SHA Actions from an allowlist, PRs plus CI for `master`, prevent version-tag updates/deletion, disable release-environment administrator bypass, and make future releases immutable.

After merge, temporarily allow `master` to use the protected `release` environment, manually run the Release workflow, inspect the uploaded signatures, and remove that temporary branch rule before tagging `v0.16.1`.

## Checks

- GitHub-hosted `App tests and build` job passed
  - pinned OpenXR loader installation
  - 35 app model tests
  - frontend production build
  - native layer build and CTest suite
  - locked Cargo check
- local `npm test` — 35 tests passed
- local `npm run build`
- `./scripts/Assert-VersionMatchesTag.ps1 -TagName v0.16.1`
- patch-notes JSON and release-workflow YAML parsing
- `git diff --check`
