### PR TITLE
Fix Tauri artifact signing order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,14 +128,15 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Sign VectorXR app and OpenXR layer
+      # This also installs the pinned ArtifactSigning PowerShell module used by
+      # Tauri's signCommand later in the job.
+      - name: Sign OpenXR layer
         uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
         with:
           endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
           files: |
-            ${{ github.workspace }}\app\src-tauri\target\release\vectorxr-app.exe
             ${{ github.workspace }}\app\src-tauri\resources\vectorxr-layer\XR_APILAYER_DIENERTECH_VECTORXR.dll
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -143,11 +144,10 @@ jobs:
           description: VectorXR
           description-url: https://github.com/DienerTech/vectorxr
 
-      - name: Verify signed app payload
+      - name: Verify signed OpenXR layer
         shell: pwsh
         run: |
           $files = @(
-            "app/src-tauri/target/release/vectorxr-app.exe",
             "app/src-tauri/resources/vectorxr-layer/XR_APILAYER_DIENERTECH_VECTORXR.dll"
           )
 
@@ -170,23 +170,29 @@ jobs:
 
       - name: Build NSIS installer
         working-directory: app
-        run: npm run tauri:bundle -- --bundles nsis
+        shell: pwsh
+        env:
+          AZURE_SIGNING_ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+        run: |
+          if (-not (Get-Module ArtifactSigning -ListAvailable -RequiredVersion "0.1.8")) {
+            throw "ArtifactSigning 0.1.8 was not installed by the layer-signing step."
+          }
+          npm run tauri:bundle -- --bundles nsis --config src-tauri/tauri.release.conf.json
 
-      - name: Sign NSIS installer
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
-        with:
-          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
-          files-folder: ${{ github.workspace }}\app\src-tauri\target\release\bundle\nsis
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-          description: VectorXR Setup
-          description-url: https://github.com/DienerTech/vectorxr
+      # Tauri signs its patched installer payload and generated uninstaller.
+      # Sign the separate standalone binary only after bundling so no later
+      # packaging operation can invalidate its signature.
+      - name: Sign standalone VectorXR app
+        shell: pwsh
+        env:
+          AZURE_SIGNING_ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+        run: ./scripts/Sign-TauriArtifact.ps1 "app/src-tauri/target/release/vectorxr-app.exe"
 
-      - name: Verify signed installer
+      - name: Verify signed release payload
         shell: pwsh
         run: |
           $installers = @(Get-ChildItem -Path "app/src-tauri/target/release/bundle/nsis" -Filter "*.exe")
@@ -194,19 +200,27 @@ jobs:
             throw "Expected exactly one NSIS installer, found $($installers.Count)."
           }
 
-          $signature = Get-AuthenticodeSignature -LiteralPath $installers[0].FullName
-          Write-Host "$($installers[0].Name) : $($signature.Status) : $($signature.SignerCertificate.Subject)"
-          if ($signature.Status -ne "Valid") {
-            throw "Invalid Authenticode signature for '$($installers[0].Name)': $($signature.Status)."
-          }
+          $files = @(
+            "app/src-tauri/target/release/vectorxr-app.exe",
+            "app/src-tauri/resources/vectorxr-layer/XR_APILAYER_DIENERTECH_VECTORXR.dll",
+            $installers[0].FullName
+          )
 
-          if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|$)' -or
-              $signature.SignerCertificate.Subject -notmatch '(^|,\s*)O=DienerTech LLC(,|$)') {
-            throw "Unexpected Authenticode publisher for '$($installers[0].Name)': $($signature.SignerCertificate.Subject)."
-          }
+          foreach ($file in $files) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $file
+            Write-Host "$file : $($signature.Status) : $($signature.SignerCertificate.Subject)"
+            if ($signature.Status -ne "Valid") {
+              throw "Invalid Authenticode signature for '$file': $($signature.Status)."
+            }
 
-          if (-not $signature.TimeStamperCertificate) {
-            throw "The Authenticode signature for '$($installers[0].Name)' does not contain a trusted timestamp."
+            if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|$)' -or
+                $signature.SignerCertificate.Subject -notmatch '(^|,\s*)O=DienerTech LLC(,|$)') {
+              throw "Unexpected Authenticode publisher for '$file': $($signature.SignerCertificate.Subject)."
+            }
+
+            if (-not $signature.TimeStamperCertificate) {
+              throw "The Authenticode signature for '$file' does not contain a trusted timestamp."
+            }
           }
 
       - name: Upload signing smoke-test artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify tagged commit belongs to master
+        if: github.event_name == 'push'
         shell: pwsh
         run: |
           git merge-base --is-ancestor $env:GITHUB_SHA refs/remotes/origin/master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,9 +177,6 @@ jobs:
           AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_SIGNING_ACCOUNT }}
           AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
         run: |
-          if (-not (Get-Module ArtifactSigning -ListAvailable -RequiredVersion "0.1.8")) {
-            throw "ArtifactSigning 0.1.8 was not installed by the layer-signing step."
-          }
           npm run tauri:bundle -- --bundles nsis --config src-tauri/tauri.release.conf.json
 
       # Tauri signs its patched installer payload and generated uninstaller.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,18 @@ jobs:
           AZURE_SIGNING_ACCOUNT: ${{ vars.AZURE_SIGNING_ACCOUNT }}
           AZURE_CERTIFICATE_PROFILE: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
         run: |
-          npm run tauri:bundle -- --bundles nsis --config src-tauri/tauri.release.conf.json
+          try {
+            npm run tauri:bundle -- --bundles nsis --config src-tauri/tauri.release.conf.json
+            if ($LASTEXITCODE -ne 0) {
+              throw "Tauri bundle failed with exit code $LASTEXITCODE."
+            }
+          } finally {
+            $signingLog = Join-Path $env:RUNNER_TEMP "vectorxr-tauri-signing.log"
+            if (Test-Path -LiteralPath $signingLog) {
+              Write-Host "Tauri signing log:"
+              Get-Content -LiteralPath $signingLog
+            }
+          }
 
       # Tauri signs its patched installer payload and generated uninstaller.
       # Sign the separate standalone binary only after bundling so no later

--- a/app/src-tauri/tauri.release.conf.json
+++ b/app/src-tauri/tauri.release.conf.json
@@ -1,0 +1,19 @@
+{
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "pwsh",
+        "args": [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "../scripts/Sign-TauriArtifact.ps1",
+          "%1"
+        ]
+      }
+    }
+  }
+}

--- a/app/src-tauri/tauri.release.conf.json
+++ b/app/src-tauri/tauri.release.conf.json
@@ -10,7 +10,7 @@
           "-ExecutionPolicy",
           "Bypass",
           "-File",
-          "../scripts/Sign-TauriArtifact.ps1",
+          "../../scripts/Sign-TauriArtifact.ps1",
           "%1"
         ]
       }

--- a/scripts/Sign-TauriArtifact.ps1
+++ b/scripts/Sign-TauriArtifact.ps1
@@ -7,6 +7,24 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$logPath = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+    Join-Path ([System.IO.Path]::GetTempPath()) "vectorxr-tauri-signing.log"
+} else {
+    Join-Path $env:RUNNER_TEMP "vectorxr-tauri-signing.log"
+}
+
+function Write-SigningLog {
+    param([string]$Message)
+
+    $timestamp = [DateTimeOffset]::UtcNow.ToString("o")
+    "$timestamp $Message" | Add-Content -LiteralPath $logPath -Encoding utf8
+}
+
+trap {
+    Write-SigningLog "FAILED: $($_.Exception.ToString())"
+    throw
+}
+
 $requiredVariables = @(
     "AZURE_SIGNING_ENDPOINT",
     "AZURE_SIGNING_ACCOUNT",
@@ -24,7 +42,10 @@ if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
     throw "Tauri signing target is not a file: $resolvedPath"
 }
 
+Write-SigningLog "Signing target: $resolvedPath"
+Write-SigningLog "PowerShell: $($PSVersionTable.PSVersion)"
 Import-Module ArtifactSigning -RequiredVersion "0.1.8" -ErrorAction Stop
+Write-SigningLog "Imported ArtifactSigning 0.1.8."
 
 $signingParameters = @{
     Endpoint                            = $env:AZURE_SIGNING_ENDPOINT
@@ -50,6 +71,7 @@ $signingParameters = @{
 
 Write-Host "Signing Tauri artifact: $resolvedPath"
 Invoke-ArtifactSigning @signingParameters
+Write-SigningLog "Artifact Signing command completed."
 
 $signature = Get-AuthenticodeSignature -LiteralPath $resolvedPath
 Write-Host "$resolvedPath : $($signature.Status) : $($signature.SignerCertificate.Subject)"
@@ -66,3 +88,5 @@ if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|
 if (-not $signature.TimeStamperCertificate) {
     throw "The Authenticode signature for '$resolvedPath' does not contain a trusted timestamp."
 }
+
+Write-SigningLog "Verified DienerTech publisher and trusted timestamp."

--- a/scripts/Sign-TauriArtifact.ps1
+++ b/scripts/Sign-TauriArtifact.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$FilePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$requiredVariables = @(
+    "AZURE_SIGNING_ENDPOINT",
+    "AZURE_SIGNING_ACCOUNT",
+    "AZURE_CERTIFICATE_PROFILE"
+)
+
+foreach ($name in $requiredVariables) {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
+        throw "Required signing variable '$name' is not configured."
+    }
+}
+
+$resolvedPath = (Resolve-Path -LiteralPath $FilePath -ErrorAction Stop).Path
+if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+    throw "Tauri signing target is not a file: $resolvedPath"
+}
+
+Import-Module ArtifactSigning -RequiredVersion "0.1.8" -ErrorAction Stop
+
+$signingParameters = @{
+    Endpoint                            = $env:AZURE_SIGNING_ENDPOINT
+    CodeSigningAccountName             = $env:AZURE_SIGNING_ACCOUNT
+    CertificateProfileName             = $env:AZURE_CERTIFICATE_PROFILE
+    Files                               = $resolvedPath
+    FileDigest                          = "SHA256"
+    TimestampRfc3161                    = "http://timestamp.acs.microsoft.com"
+    TimestampDigest                     = "SHA256"
+    Description                         = "VectorXR"
+    DescriptionUrl                      = "https://github.com/DienerTech/vectorxr"
+    ExcludeEnvironmentCredential        = $true
+    ExcludeWorkloadIdentityCredential   = $true
+    ExcludeManagedIdentityCredential    = $true
+    ExcludeSharedTokenCacheCredential   = $true
+    ExcludeVisualStudioCredential       = $true
+    ExcludeVisualStudioCodeCredential   = $true
+    ExcludeAzureCliCredential           = $false
+    ExcludeAzurePowerShellCredential    = $true
+    ExcludeAzureDeveloperCliCredential  = $true
+    ExcludeInteractiveBrowserCredential = $true
+}
+
+Write-Host "Signing Tauri artifact: $resolvedPath"
+Invoke-ArtifactSigning @signingParameters
+
+$signature = Get-AuthenticodeSignature -LiteralPath $resolvedPath
+Write-Host "$resolvedPath : $($signature.Status) : $($signature.SignerCertificate.Subject)"
+
+if ($signature.Status -ne "Valid") {
+    throw "Invalid Authenticode signature for '$resolvedPath': $($signature.Status)."
+}
+
+if ($signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=DienerTech LLC(,|$)' -or
+    $signature.SignerCertificate.Subject -notmatch '(^|,\s*)O=DienerTech LLC(,|$)') {
+    throw "Unexpected Authenticode publisher for '$resolvedPath': $($signature.SignerCertificate.Subject)."
+}
+
+if (-not $signature.TimeStamperCertificate) {
+    throw "The Authenticode signature for '$resolvedPath' does not contain a trusted timestamp."
+}


### PR DESCRIPTION
## What changed

- move Windows app signing into Tauri's release-only `signCommand`
- reuse the existing secretless Azure CLI/OIDC session from the release job
- sign the patched app and generated NSIS uninstaller as part of packaging
- sign the standalone app executable after bundling
- retain publisher, timestamp, and signature verification for every published executable payload
- scope the master-ancestry guard to real tag pushes so exact-branch manual smoke tests remain possible

## Why

The initial signing smoke test showed that Tauri patched the application executable after the workflow's original pre-bundle signature. The installed app therefore had `HashMismatch`, and the generated uninstaller was unsigned, even though the outer installer and staged source executable verified successfully.

This change signs artifacts at their final mutation point so packaging cannot invalidate their Authenticode signatures.

## Validation

- `npm test` — 35/35 passed locally
- `App tests and build` — passed on PR head
- [manual signing smoke workflow](https://github.com/DienerTech/vectorxr/actions/runs/31560739637) — passed end to end
- downloaded app, layer DLL, and installer independently verified as `Valid`, published by DienerTech LLC, and timestamped
- installed 0.16.1 payload independently verified:
  - `vectorxr-app.exe` — valid and timestamped
  - `uninstall.exe` — valid and timestamped
  - OpenXR layer DLL — valid and timestamped
  - manifest/registry registration — valid and enabled
- temporary exact-branch release-environment policy removed; environment is restored to tag-only `v*.*.*`