### PR TITLE
Fix GitHub Release publication context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           $tag = "${{ github.ref_name }}"
           $notesPath = Join-Path $env:GITHUB_WORKSPACE "release-assets/release-notes.md"


### PR DESCRIPTION
## What changed

Set `GH_REPO` from `github.repository` in the release publication job.

## Why

The publication job intentionally downloads the signed release payload without checking out source. GitHub CLI therefore could not infer a repository and failed with `fatal: not a git repository`, after the v0.16.1 signed build had completed successfully.

`GH_REPO` gives every `gh release` command in that step an explicit repository context without adding an unnecessary checkout or broader token permissions.

## Validation

- reproduced the original repository-inference condition from a directory with no Git checkout
- confirmed `gh release view v0.16.1` succeeds there when `GH_REPO=DienerTech/vectorxr`
- `git diff --check` passed
- v0.16.1 was recovered from the exact signed workflow artifact and published successfully