### PR TITLE
Release VectorXR 0.16.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           $tag = "${{ github.ref_name }}"
           $notesPath = Join-Path $env:GITHUB_WORKSPACE "release-assets/release-notes.md"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(VectorXR VERSION 0.5.0 LANGUAGES CXX)
 
 option(DEPTHXR_BUILD_LAYER "Build the Windows OpenXR API layer" ON)
 option(DEPTHXR_BUILD_TESTS "Build VectorXR layer tests" ON)
+option(DEPTHXR_BUILD_HARDWARE_PROBES "Build opt-in real-runtime OpenXR diagnostic clients" OFF)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Patch-note summaries and item text support the attribute-free inline tags `<stro
 - `examples/`: sample settings
 - `scripts/`: Windows build, install, staging, and release helpers
 
+An opt-in real-runtime OpenXR diagnostic client is also available for
+deterministic Pivot reference-space and Turbo frame-threading tests. See the
+[hardware probe guide](docs/hardware-probe.md).
+
 ## Acknowledgments
 
 VectorXR exists in the wider OpenXR community, and several open source projects helped shape it.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectorxr-app",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectorxr-app",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@tauri-apps/api": "~2.10.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vectorxr-app",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "vectorxr-app"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorxr-app"
-version = "0.16.1"
+version = "0.16.2"
 description = "VectorXR configuration app"
 authors = ["mdiener"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VectorXR",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "identifier": "local.vectorxr.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/app/src/lib/patchNotes.json
+++ b/app/src/lib/patchNotes.json
@@ -1,5 +1,45 @@
 [
   {
+    "version": "0.16.2",
+    "date": "2026-08-18",
+    "title": "Smoother Turbo and More Reliable Pivot",
+    "summary": "Makes Turbo more dependable in DCS, keeps Pivot movement stable in complex rendering situations, improves Quadviews diagnostics and controller reconnects, and adds a headset test utility for validating future fixes.",
+    "items": [
+      {
+        "html": "<strong>Smoother Turbo</strong>",
+        "items": [
+          "Fixes a rare freeze that could occur when a game began preparing its next frame unusually early.",
+          "Keeps timing consistent when games request extra frame updates and recovers safely when a frame cannot be submitted.",
+          "Adds broader automated testing for Turbo startup, steady play, failure recovery, and compatibility fallbacks."
+        ]
+      },
+      {
+        "html": "<strong>More reliable Pivot movement</strong>",
+        "items": [
+          "Keeps the same Pivot adjustment throughout each displayed frame, even when a game checks headset tracking more than once.",
+          "Corrects Pivot in games that prepare tracking and the final image through different rendering paths, preventing movement from being applied from the wrong point of reference.",
+          "Handles unusual rendering layouts more cautiously, preferring an unchanged view over a potentially incorrect Pivot adjustment."
+        ]
+      },
+      {
+        "html": "<strong>Clearer Quadviews diagnostics and controller recovery</strong>",
+        "items": [
+          "Keeps Quadviews focus and gaze guides aligned with the image actually being displayed, even when a game prepares frames ahead of time.",
+          "Slows repeated checks for unavailable HOTAS and joystick devices instead of retrying every frame, while allowing their bindings to recover automatically when the device returns.",
+          "Condenses repeated input failures into concise reconnect updates instead of flooding the log."
+        ]
+      },
+      {
+        "html": "<strong>A new headset test utility</strong>",
+        "items": [
+          "Adds an optional visual test app that exercises Pivot and Turbo directly on a real headset without requiring a particular sim, aircraft, or mission.",
+          "Includes several Pivot movement scenarios and a Turbo stress test designed to expose timing problems that are difficult to reproduce during normal play.",
+          "Creates a repeatable way to confirm changes across different headsets and headset software, helping future fixes arrive with stronger real-hardware validation."
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.16.1",
     "date": "2026-08-11",
     "title": "Signed Windows Releases",

--- a/app/tests/patchNotes.test.mjs
+++ b/app/tests/patchNotes.test.mjs
@@ -44,10 +44,10 @@ test('legacy and current patch notes use organized nested sections', () => {
     assert.ok(entry.items.every((item) => typeof item !== 'string'), `${entry.version} has an ungrouped top-level item`)
   }
 
-  assert.equal(patchNotes[0].version, '0.16.1')
-  assert.equal(patchNotes[0].title, 'Signed Windows Releases')
-  assert.match(patchNotes[0].summary, /signatures/)
-  assert.match(JSON.stringify(patchNotes[0].items), /OpenXR API layer/)
+  assert.equal(patchNotes[0].version, '0.16.2')
+  assert.equal(patchNotes[0].title, 'Smoother Turbo and More Reliable Pivot')
+  assert.match(patchNotes[0].summary, /DCS/)
+  assert.match(JSON.stringify(patchNotes[0].items), /headset test utility/)
   const maxDepth = Math.max(
     ...patchNotes[0].items.map((item, index) => assertItem(item, `latest.items[${index}]`)),
   )

--- a/docs/hardware-probe.md
+++ b/docs/hardware-probe.md
@@ -1,0 +1,156 @@
+# Real-runtime hardware probe
+
+`vectorxr_hardware_probe` is an opt-in developer executable for exercising
+VectorXR against the active OpenXR runtime and headset without relying on a
+game to use a particular frame loop or reference-space arrangement. It is not
+included in the VectorXR installer or the default CMake build.
+
+The probe renders an asymmetric line scene through D3D11: a ground grid,
+colored axes, and two differently placed beacons. Each eye is limited to
+1280 pixels in either dimension so the diagnostic does not allocate the
+headset's full recommended render size.
+
+## Build
+
+Configure a dedicated build tree from the repository root:
+
+```powershell
+cmake -S . -B build/hardware-probe `
+  -DDEPTHXR_BUILD_HARDWARE_PROBES=ON `
+  -DDEPTHXR_BUILD_TESTS=ON
+cmake --build build/hardware-probe --config RelWithDebInfo `
+  --target vectorxr_hardware_probe --parallel
+```
+
+The executable and a matching OpenXR loader DLL are written to:
+
+```text
+build\hardware-probe\layer\RelWithDebInfo\vectorxr_hardware_probe.exe
+```
+
+The non-headset pose-math check can run in CI or from a desktop session:
+
+```powershell
+.\build\hardware-probe\layer\RelWithDebInfo\vectorxr_hardware_probe.exe --self-test
+```
+
+## Prepare VectorXR
+
+1. Enable the VectorXR OpenXR layer and set logging to **Debug**.
+2. Ensure Pivot applies to `vectorxr_hardware_probe.exe`. A default Pivot
+   profile is sufficient, or add an application-specific profile after the
+   probe first appears in the Application Registry.
+3. Use a Pivot action with both yaw and pitch. A combined Snap View makes a
+   space-axis error much easier to see than pure yaw.
+4. Leave Turbo on **Auto** for the Pivot-only runs.
+
+The probe creates two distinct `LOCAL` reference spaces. The source has an
+identity offset. The target is translated and yawed 90 degrees. Using two
+`LOCAL` handles avoids depending on optional `STAGE` support while still
+requiring a real coordinate conversion.
+
+## Pivot routing modes
+
+Run one mode per OpenXR session so each produces a clean VectorXR log:
+
+```powershell
+$probe = '.\build\hardware-probe\layer\RelWithDebInfo\vectorxr_hardware_probe.exe'
+
+& $probe --mode source-exact --seconds 20
+& $probe --mode cross-space --seconds 20
+& $probe --mode cross-space-cached --seconds 20
+```
+
+Press Escape in the console window to end a run early.
+
+| Mode | LocateViews calls | Projection space | Expected resolution |
+| --- | --- | --- | --- |
+| `source-exact` | Source `LOCAL` | Source `LOCAL` | `source_exact` |
+| `cross-space` | Source `LOCAL` | Offset `LOCAL` | `canonical_view_locate` |
+| `cross-space-cached` | Source and offset `LOCAL` at the same display time | Offset `LOCAL` | `located_views_cache` |
+
+The cross-space modes render from the source-space views, obtain the runtime's
+source-to-target relation, and submit equivalent poses in the target space.
+The scene should therefore look the same in all three modes. With Pivot active,
+an unconverted pitch correction would become diagonal or roll-like in the
+90-degree-yawed target space; translation mistakes tend to look like an orbit
+or lateral jump.
+
+### Log pass criteria
+
+A cross-space run should contain an information line similar to:
+
+```text
+PivotXR space-aware projection correction active: ...
+resolution=canonical_view_locate
+```
+
+Its EndFrame diagnostics should show:
+
+```text
+spaceConversions=1
+spaceConversionFailures=0
+```
+
+The cached run should instead show `resolution=located_views_cache`, and its
+LocateViews diagnostics should eventually show `logicalFrameReused=1`. This
+confirms that a second world-space LocateViews query for one display time reused
+the first logical Pivot update and cached the correction in the second space.
+
+The source-exact run is the control. It should remain `resolution=source_exact`
+with zero space-relation queries and conversions.
+
+For all modes, treat any of these as failures:
+
+- `PivotXR projection-space conversion failed`
+- `spaceConversionFailures` greater than zero
+- repeated continuity misses during steady Pivot motion
+- a visible axis change, orbit, or jump between the control and cross-space runs
+- an OpenXR or swapchain error printed by the probe
+
+An isolated activation-boundary continuity miss followed by an exact recovery
+on the next frame is recorded separately from a sustained routing failure.
+
+## Async handoff mode
+
+`--threaded-wait` uses a persistent application wait thread. It requests
+`xrWaitFrame(N+1)` immediately before the render thread submits
+`xrEndFrame(N)`, reproducing the legal overlapping call pattern used by DCS.
+
+To exercise VectorXR's async handoff shield:
+
+1. Fully close any active OpenXR application.
+2. Force **Turbo > Frame Pacing > Async** in VectorXR.
+3. Run a cross-space mode with threaded waiting:
+
+```powershell
+& $probe --mode cross-space --threaded-wait --seconds 30
+```
+
+Expected debug evidence includes:
+
+```text
+Turbo pacing: async (forced in settings...)
+Turbo-diag: async handoff shield armed
+Turbo-diag: app xrWaitFrame intercepted by async handoff shield
+Turbo-diag: async handoff published runtime wait
+Frame pacing ... pacing=async ... asyncHandoff ...
+```
+
+Healthy handoff windows have increasing armed/wait/begin counters and no
+cancellations. PiOpenXR is known to interlock an off-thread `xrWaitFrame` with
+submission, so forced Async may produce approximately 250 ms stalls and
+auto-suspend after five drain timeouts. That outcome still exercises the
+handoff and safety path, but it does not establish that sustained Async is
+compatible with that driver. Restore Frame Pacing to **Auto** after the test.
+
+## What this probe does not prove
+
+- It does not replace game-specific functional testing or verify a game's own
+  swapchain and rendering behavior.
+- A single-threaded run does not exercise the async handoff race; use
+  `--threaded-wait` explicitly.
+- The probe reports errors from its own OpenXR calls, while VectorXR's routing
+  verdict remains in the corresponding `%LOCALAPPDATA%\VectorXR\logs` file.
+- The probe does not change VectorXR settings, bindings, or runtime selection.
+

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -142,6 +142,39 @@ if(WIN32 AND DEPTHXR_BUILD_LAYER)
                 ${CMAKE_CURRENT_SOURCE_DIR}/assets/sounds/depth-lock-off.wav
                 $<TARGET_FILE_DIR:XR_APILAYER_DIENERTECH_VECTORXR>/sounds/
     )
+
+    if(DEPTHXR_BUILD_TESTS)
+        # Compile the real frame-loop implementation into a dedicated fake-runtime
+        # harness. DEPTHXR_TESTING only grants the harness state setup/inspection
+        # access; no test hooks are present in the shipping layer target.
+        add_executable(
+            depthxr_turbo_frame_tests
+            tests/turbo_frame_tests.cpp
+            src/openxr_layer.cpp
+        )
+        target_include_directories(depthxr_turbo_frame_tests PRIVATE include)
+        target_link_libraries(
+            depthxr_turbo_frame_tests
+            PRIVATE
+            depthxr_core
+            OpenXR::openxr_loader
+            d3d11
+            d3dcompiler
+            dxgi
+            shlwapi
+        )
+        target_compile_definitions(
+            depthxr_turbo_frame_tests
+            PRIVATE
+            DEPTHXR_TESTING
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            XR_USE_GRAPHICS_API_D3D11
+            VECTORXR_VERSION="${_vectorxr_version}"
+        )
+        add_test(NAME depthxr_turbo_frame_tests COMMAND depthxr_turbo_frame_tests)
+        set_tests_properties(depthxr_turbo_frame_tests PROPERTIES TIMEOUT 15)
+    endif()
 endif()
 
 if(DEPTHXR_BUILD_TESTS)

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -143,6 +143,47 @@ if(WIN32 AND DEPTHXR_BUILD_LAYER)
                 $<TARGET_FILE_DIR:XR_APILAYER_DIENERTECH_VECTORXR>/sounds/
     )
 
+    if(DEPTHXR_BUILD_HARDWARE_PROBES)
+        add_executable(
+            vectorxr_hardware_probe
+            tools/pivot_space_probe.cpp
+        )
+        target_link_libraries(
+            vectorxr_hardware_probe
+            PRIVATE
+            OpenXR::openxr_loader
+            d3d11
+            d3dcompiler
+            dxgi
+        )
+        target_compile_definitions(
+            vectorxr_hardware_probe
+            PRIVATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            XR_USE_PLATFORM_WIN32
+            XR_USE_GRAPHICS_API_D3D11
+        )
+        if(MSVC)
+            target_compile_options(vectorxr_hardware_probe PRIVATE /W4 /permissive-)
+        endif()
+        add_custom_command(
+            TARGET vectorxr_hardware_probe
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    $<TARGET_FILE:OpenXR::openxr_loader>
+                    $<TARGET_FILE_DIR:vectorxr_hardware_probe>
+        )
+
+        if(DEPTHXR_BUILD_TESTS)
+            add_test(
+                NAME vectorxr_hardware_probe_self_test
+                COMMAND vectorxr_hardware_probe --self-test
+            )
+            set_tests_properties(vectorxr_hardware_probe_self_test PROPERTIES TIMEOUT 10)
+        endif()
+    endif()
+
     if(DEPTHXR_BUILD_TESTS)
         # Compile the real frame-loop implementation into a dedicated fake-runtime
         # harness. DEPTHXR_TESTING only grants the harness state setup/inspection

--- a/layer/include/depthxr/input_devices.h
+++ b/layer/include/depthxr/input_devices.h
@@ -2,10 +2,13 @@
 
 #include "depthxr/settings.h"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 
 namespace depthxr {
 
@@ -37,6 +40,11 @@ enum class InputBindingPollStage {
 struct InputBindingPollResult {
     bool down{false};
     bool device_poll_attempted{false};
+    // True when a known-unavailable device was left inactive without another
+    // DirectInput call. This preserves diagnostics while preventing reconnect
+    // attempts from running at the frame-loop polling rate.
+    bool device_retry_deferred{false};
+    std::int64_t device_retry_delay_ms{0};
     InputBindingPollStage diagnostic_stage{InputBindingPollStage::None};
     std::int64_t result_code{0};
     bool reacquire_attempted{false};
@@ -45,6 +53,37 @@ struct InputBindingPollResult {
     std::int64_t retry_result_code{0};
     bool recovered{false};
     std::uintptr_t cooperative_window{0};
+};
+
+// Per-device reconnect policy used after DirectInput setup/read failures.
+// The poller owns synchronization; this small policy object is deliberately
+// clock-driven so its storm-prevention behavior can be tested deterministically.
+class InputDeviceRetryBackoff {
+  public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    explicit InputDeviceRetryBackoff(
+        std::chrono::milliseconds initial_delay = std::chrono::milliseconds{250},
+        std::chrono::milliseconds maximum_delay = std::chrono::milliseconds{2000});
+
+    bool ShouldAttempt(const std::wstring& device_key, TimePoint now) const;
+    std::chrono::milliseconds RecordFailure(const std::wstring& device_key, TimePoint now);
+    void RecordSuccess(const std::wstring& device_key);
+    std::chrono::milliseconds RetryDelayRemaining(const std::wstring& device_key,
+                                                   TimePoint now) const;
+    std::size_t ConsecutiveFailures(const std::wstring& device_key) const;
+
+  private:
+    struct Entry {
+        TimePoint retry_after{};
+        std::chrono::milliseconds delay{0};
+        std::size_t consecutive_failures{0};
+    };
+
+    std::chrono::milliseconds initial_delay_;
+    std::chrono::milliseconds maximum_delay_;
+    std::unordered_map<std::wstring, Entry> entries_;
 };
 
 std::optional<DeviceInputPath> ParseDeviceInputPath(std::string_view input_path);

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -507,9 +507,47 @@ class OpenXrLayer {
         std::array<XrFovf, 4> fovs{};
         QuadViewsGazeDiagnostic gaze;
     };
-    void CachePivotPoseDelta(XrTime time, const XrPosef& pose_delta);
-    bool FindPivotPoseDelta(XrTime time, XrPosef* pose_delta, XrTime* matched_time) const;
+    struct PivotSpacePoseDelta {
+        XrSpace space{XR_NULL_HANDLE};
+        XrPosef pose_delta{{0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f}};
+    };
+    struct PivotPoseDeltaFrame {
+        // The VIEW-space representation is the frame's canonical logical
+        // Pivot update. Per-space values are derived from it and never drive
+        // smoothing a second time.
+        XrPosef canonical_view_pose_delta{{0.0f, 0.0f, 0.0f, 1.0f},
+                                          {0.0f, 0.0f, 0.0f}};
+        XrSpace source_space{XR_NULL_HANDLE};
+        // OpenXR applications normally submit one projection space. Keep a
+        // small fixed cache for multi-query/multi-layer games so frame records
+        // and one-frame continuity never allocate on the hot path.
+        static constexpr std::size_t kMaxSpacePoseDeltas = 8;
+        std::array<PivotSpacePoseDelta, kMaxSpacePoseDeltas> space_pose_deltas{};
+        std::size_t space_pose_delta_count{0};
+    };
+    struct ResolvedPivotSpaceDelta {
+        XrSpace space{XR_NULL_HANDLE};
+        XrPosef forward{{0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f}};
+        XrPosef reverse{{0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f}};
+        XrResult locate_result{XR_SUCCESS};
+        XrSpaceLocationFlags location_flags{0};
+        double locate_duration_us{0.0};
+        bool available{false};
+        bool non_identity{false};
+        std::string_view mode{"none"};
+    };
+    bool CachePivotPoseDelta(XrTime time,
+                             XrSpace source_space,
+                             const XrPosef& source_pose_delta,
+                             const XrPosef& view_pose_in_source);
+    bool FindPivotPoseDeltaForSpace(const PivotPoseDeltaFrame& frame,
+                                    XrSpace space,
+                                    XrPosef* pose_delta) const;
+    void CachePivotPoseDeltaForSpace(PivotPoseDeltaFrame& frame,
+                                     XrSpace space,
+                                     const XrPosef& pose_delta) const;
     void PrunePivotPoseDeltas(XrTime time);
+    std::string DescribeSpace(XrSpace space) const;
     void CacheDepthSubmissionGeometry(XrTime time,
                                       XrSpace space,
                                       XrViewConfigurationType view_configuration_type,
@@ -682,7 +720,7 @@ class OpenXrLayer {
     std::optional<std::chrono::steady_clock::time_point> pivotxr_last_smoothing_wall_time_;
     // EndFrame can occasionally arrive without a matching LocateViews cache
     // entry. Bridge one such miss so amplified poses do not flash to identity.
-    std::optional<XrPosef> pivotxr_last_matched_pose_delta_;
+    std::optional<PivotPoseDeltaFrame> pivotxr_last_matched_pose_delta_;
     std::size_t pivotxr_consecutive_pose_delta_misses_{0};
     // Per resolved-profile input edge state, index-aligned with
     // resolved_settings_.pivotxr.profiles. Arbitration is last-pressed-wins:
@@ -1104,7 +1142,12 @@ class OpenXrLayer {
     std::vector<std::vector<XrCompositionLayerProjectionView>> end_frame_projection_views_scratch_;
     std::vector<XrCompositionLayerProjection> end_frame_projection_layers_scratch_;
     std::vector<const XrCompositionLayerBaseHeader*> end_frame_layers_scratch_;
-    std::map<XrTime, XrPosef> cached_pivot_pose_deltas_;
+    std::vector<ResolvedPivotSpaceDelta> end_frame_pivot_space_deltas_scratch_;
+    std::map<XrTime, PivotPoseDeltaFrame> cached_pivot_pose_deltas_;
+    // Info-level breadcrumbs are emitted once per submitted space, while
+    // debug diagnostics retain per-frame details without spamming normal logs.
+    std::unordered_set<XrSpace> logged_pivot_space_conversions_;
+    std::unordered_set<XrSpace> failed_pivot_space_conversions_;
     std::map<XrTime, std::vector<DepthSubmissionGeometry>> cached_depth_submission_geometry_;
     QuadViewsFrameCache<QuadViewsFrameState> cached_quadviews_frames_;
     std::unordered_map<XrSwapchain, SwapchainInfo> tracked_swapchains_;

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -26,6 +26,7 @@
 #include "depthxr/pivot_view.h"
 #include "depthxr/effects.h"
 #include "depthxr/logger.h"
+#include "depthxr/quadviews_frame_cache.h"
 #include "depthxr/quadviews_recovery.h"
 #include "depthxr/runtime_compatibility.h"
 #include "depthxr/runtime_pacing.h"
@@ -495,6 +496,17 @@ class OpenXrLayer {
         std::vector<XrFovf> native_fovs;
         std::vector<XrFovf> render_fovs;
     };
+    struct QuadViewsGazeDiagnostic {
+        bool valid{false};
+        double raw_yaw_radians{0.0};
+        double raw_pitch_radians{0.0};
+        double smoothed_yaw_radians{0.0};
+        double smoothed_pitch_radians{0.0};
+    };
+    struct QuadViewsFrameState {
+        std::array<XrFovf, 4> fovs{};
+        QuadViewsGazeDiagnostic gaze;
+    };
     void CachePivotPoseDelta(XrTime time, const XrPosef& pose_delta);
     bool FindPivotPoseDelta(XrTime time, XrPosef* pose_delta, XrTime* matched_time) const;
     void PrunePivotPoseDeltas(XrTime time);
@@ -515,9 +527,11 @@ class OpenXrLayer {
                                             const DepthSubmissionGeometry& geometry,
                                             const XrPosef& reverse_pose_delta,
                                             bool has_reverse_pose_delta) const;
-    void CacheQuadViewsFovs(XrTime time, std::span<const XrView> views);
-    bool FindQuadViewsFovs(XrTime time, std::array<XrFovf, 4>* fovs, XrTime* matched_time) const;
-    void PruneQuadViewsFovs(XrTime time);
+    void CacheQuadViewsFrame(XrTime time,
+                             std::span<const XrView> views,
+                             const QuadViewsGazeDiagnostic& gaze);
+    bool FindQuadViewsFrame(XrTime time, QuadViewsFrameState* frame, XrTime* matched_time) const;
+    void PruneQuadViewsFrames(XrTime time);
     bool IsTrackedViewSpace(XrSpace space) const;
     XrResult LocateRuntimeViews(XrSession session,
                                 const XrViewLocateInfo* view_locate_info,
@@ -525,7 +539,8 @@ class OpenXrLayer {
                                 uint32_t view_capacity_input,
                                 uint32_t* view_count_output,
                                 XrView* views,
-                                bool* synthesized_quad_views);
+                                bool* synthesized_quad_views,
+                                QuadViewsGazeDiagnostic* gaze_diagnostic);
     void RecordVarjoNativeLocateDiagnostics(const XrViewLocateInfo* view_locate_info,
                                             bool vector_request_injected,
                                             bool rendering_gaze_queried,
@@ -1091,7 +1106,7 @@ class OpenXrLayer {
     std::vector<const XrCompositionLayerBaseHeader*> end_frame_layers_scratch_;
     std::map<XrTime, XrPosef> cached_pivot_pose_deltas_;
     std::map<XrTime, std::vector<DepthSubmissionGeometry>> cached_depth_submission_geometry_;
-    std::map<XrTime, std::array<XrFovf, 4>> cached_quadviews_fovs_;
+    QuadViewsFrameCache<QuadViewsFrameState> cached_quadviews_frames_;
     std::unordered_map<XrSwapchain, SwapchainInfo> tracked_swapchains_;
     D3D11QuadViewsCompositor d3d11_quadviews_compositor_;
     D3D11FocusSharpen d3d11_focus_sharpen_;

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -408,6 +408,9 @@ class OpenXrLayer {
                              const XrFrameEndInfo* frame_end_info,
                              std::unique_lock<std::mutex>& config_lock);
     void ObserveCompositionLayerTopology(const XrFrameEndInfo* frame_end_info);
+    void ArmTurboAsyncHandoffLocked(const char* reason);
+    void PublishTurboAsyncHandoffLocked();
+    void CancelTurboAsyncHandoffLocked(const char* reason);
     void EnsureTurboAsyncWorkerLocked();
     void StopTurboAsyncWorker();
     void TurboAsyncWorkerLoop();
@@ -754,6 +757,22 @@ class OpenXrLayer {
     std::atomic<bool> turbo_frame_interception_required_{false};
     std::mutex turbo_mutex_;
     std::condition_variable turbo_async_worker_cv_;
+    // Async pacing must never expose a pass-through gap between retiring one
+    // runtime wait and publishing the next. DCS can call xrWaitFrame from its
+    // sim thread while xrEndFrame is still running on the render thread; if
+    // that app wait reaches the runtime during the gap, the replacement worker
+    // issues a second real wait and runtimes such as Virtual Desktop's Oculus
+    // compatibility path interlock until the slipped wait receives a Begin.
+    // The handoff shield keeps app Wait/Begin calls fabricated across that
+    // drain -> Begin -> End -> replacement-publication window.
+    std::condition_variable turbo_async_handoff_cv_;
+    bool turbo_async_handoff_active_{false};
+    std::uint64_t turbo_async_handoff_armed_total_{0};
+    std::uint64_t turbo_async_handoff_wait_intercepts_{0};
+    std::uint64_t turbo_async_handoff_begin_intercepts_{0};
+    std::uint64_t turbo_async_handoff_second_poll_blocks_{0};
+    std::uint64_t turbo_async_handoff_cancellations_{0};
+    int turbo_async_handoff_debug_log_budget_{0};
     std::thread turbo_async_worker_;
     bool turbo_async_worker_stop_{false};
     bool turbo_async_job_pending_{false};

--- a/layer/include/depthxr/openxr_layer.h
+++ b/layer/include/depthxr/openxr_layer.h
@@ -50,6 +50,10 @@ struct ID3D11VertexShader;
 
 namespace depthxr {
 
+#if defined(DEPTHXR_TESTING)
+class TurboFrameTestPeer;
+#endif
+
 class OpenXrLayer {
   public:
     static OpenXrLayer& Instance();
@@ -178,6 +182,10 @@ class OpenXrLayer {
                          XrView* views);
 
   private:
+#if defined(DEPTHXR_TESTING)
+    friend class TurboFrameTestPeer;
+#endif
+
     OpenXrLayer() = default;
     ~OpenXrLayer();
 

--- a/layer/include/depthxr/pivot_routing.h
+++ b/layer/include/depthxr/pivot_routing.h
@@ -26,12 +26,31 @@ enum class PivotPoseDeltaSelection {
     HeldPrevious,
 };
 
+// A display time identifies one logical Pivot update. Keep the first
+// world-space result for that time so repeated xrLocateViews calls cannot
+// advance smoothing or make the eventual correction depend on call order.
 template <typename Time, typename Pose>
-void CachePivotPoseDeltaValue(std::map<Time, Pose>& cache, Time time, const Pose& pose_delta) {
-    cache[time] = pose_delta;
+bool CachePivotPoseDeltaValue(std::map<Time, Pose>& cache, Time time, const Pose& pose_delta) {
+    const bool inserted = cache.try_emplace(time, pose_delta).second;
     while (cache.size() > kPivotPoseDeltaMaxEntries) {
         cache.erase(cache.begin());
     }
+    return inserted;
+}
+
+// Re-express a rigid pose delta from one coordinate space into another. The
+// caller supplies conventional pose composition (lhs * rhs) and inversion so
+// this routing helper remains independent of the OpenXR SDK types.
+//
+// If source_in_target maps source-space poses into target space, a delta D is
+// represented in target space by source_in_target * D * inverse(source_in_target).
+template <typename Pose, typename Compose, typename Invert>
+Pose ReexpressPivotPoseDelta(const Pose& pose_delta_in_source,
+                             const Pose& source_in_target,
+                             Compose compose,
+                             Invert invert) {
+    return compose(compose(source_in_target, pose_delta_in_source),
+                   invert(source_in_target));
 }
 
 template <typename Time, typename Pose>

--- a/layer/include/depthxr/quadviews_frame_cache.h
+++ b/layer/include/depthxr/quadviews_frame_cache.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <map>
+#include <utility>
+
+namespace depthxr {
+
+// Keeps the render geometry and diagnostics produced by one xrLocateViews call
+// together. OpenXR applications may locate multiple predicted frames before
+// submitting an older one, so consumers must select the complete snapshot for
+// the submitted display time instead of combining cached geometry with mutable
+// "latest" diagnostic state.
+template <typename Payload>
+class QuadViewsFrameCache {
+public:
+    void Store(std::int64_t time, Payload payload, std::size_t max_entries) {
+        if (time == 0 || max_entries == 0) {
+            return;
+        }
+
+        frames_[time] = std::move(payload);
+        while (frames_.size() > max_entries) {
+            frames_.erase(frames_.begin());
+        }
+    }
+
+    bool FindNearest(std::int64_t time,
+                     std::int64_t max_delta,
+                     Payload* payload,
+                     std::int64_t* matched_time) const {
+        if (!payload || !matched_time || frames_.empty()) {
+            if (matched_time) {
+                *matched_time = 0;
+            }
+            return false;
+        }
+
+        const auto exact = frames_.find(time);
+        if (exact != frames_.end()) {
+            *payload = exact->second;
+            *matched_time = exact->first;
+            return true;
+        }
+
+        const auto upper = frames_.lower_bound(time);
+        typename std::map<std::int64_t, Payload>::const_iterator best;
+        if (upper == frames_.begin()) {
+            best = upper;
+        } else if (upper == frames_.end()) {
+            best = std::prev(upper);
+        } else {
+            const auto lower = std::prev(upper);
+            best = (time - lower->first <= upper->first - time) ? lower : upper;
+        }
+
+        const std::int64_t match_delta =
+            best->first > time ? best->first - time : time - best->first;
+        *matched_time = best->first;
+        if (match_delta > max_delta) {
+            return false;
+        }
+
+        *payload = best->second;
+        return true;
+    }
+
+    void PruneThrough(std::int64_t time) {
+        const auto keep_from = frames_.upper_bound(time);
+        if (keep_from != frames_.begin()) {
+            frames_.erase(frames_.begin(), keep_from);
+        }
+    }
+
+    void Clear() {
+        frames_.clear();
+    }
+
+    [[nodiscard]] std::size_t Size() const {
+        return frames_.size();
+    }
+
+private:
+    std::map<std::int64_t, Payload> frames_;
+};
+
+} // namespace depthxr

--- a/layer/src/input_devices.cpp
+++ b/layer/src/input_devices.cpp
@@ -167,6 +167,53 @@ const char* DirectInputResultName(std::int64_t result_code) {
     return "unknown";
 }
 
+InputDeviceRetryBackoff::InputDeviceRetryBackoff(
+    std::chrono::milliseconds initial_delay,
+    std::chrono::milliseconds maximum_delay)
+    : initial_delay_(std::max(initial_delay, std::chrono::milliseconds{1})),
+      maximum_delay_(std::max(maximum_delay, initial_delay_)) {}
+
+bool InputDeviceRetryBackoff::ShouldAttempt(const std::wstring& device_key,
+                                            TimePoint now) const {
+    const auto entry = entries_.find(device_key);
+    return entry == entries_.end() || now >= entry->second.retry_after;
+}
+
+std::chrono::milliseconds InputDeviceRetryBackoff::RecordFailure(
+    const std::wstring& device_key,
+    TimePoint now) {
+    Entry& entry = entries_[device_key];
+    if (entry.consecutive_failures == 0) {
+        entry.delay = initial_delay_;
+    } else {
+        entry.delay = std::min(entry.delay * 2, maximum_delay_);
+    }
+    ++entry.consecutive_failures;
+    entry.retry_after = now + entry.delay;
+    return entry.delay;
+}
+
+void InputDeviceRetryBackoff::RecordSuccess(const std::wstring& device_key) {
+    entries_.erase(device_key);
+}
+
+std::chrono::milliseconds InputDeviceRetryBackoff::RetryDelayRemaining(
+    const std::wstring& device_key,
+    TimePoint now) const {
+    const auto entry = entries_.find(device_key);
+    if (entry == entries_.end() || now >= entry->second.retry_after) {
+        return std::chrono::milliseconds{0};
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        entry->second.retry_after - now);
+}
+
+std::size_t InputDeviceRetryBackoff::ConsecutiveFailures(
+    const std::wstring& device_key) const {
+    const auto entry = entries_.find(device_key);
+    return entry == entries_.end() ? 0 : entry->second.consecutive_failures;
+}
+
 namespace {
 
 #if defined(_WIN32)
@@ -339,8 +386,35 @@ class DirectInputPoller {
             return result;
         }
 
+        // A missing HID can make DirectInput setup/reacquisition surprisingly
+        // expensive. Without a negative cache, every binding for the same
+        // unplugged device retries here every 30ms on the OpenXR frame path.
+        // Return the last inactive diagnostic until this device's reconnect
+        // deadline, then permit one new attempt for all of its bindings.
+        if (!retry_backoff_.ShouldAttempt(cache_key, now)) {
+            if (const auto failure = failure_diagnostics_.find(cache_key);
+                failure != failure_diagnostics_.end()) {
+                result = failure->second;
+            }
+            result.down = false;
+            result.device_poll_attempted = true;
+            result.device_retry_deferred = true;
+            result.device_retry_delay_ms =
+                retry_backoff_.RetryDelayRemaining(cache_key, now).count();
+            return result;
+        }
+
+        const auto cache_failure = [&] {
+            result.down = false;
+            result.device_retry_deferred = false;
+            result.device_retry_delay_ms =
+                retry_backoff_.RecordFailure(cache_key, InputDeviceRetryBackoff::Clock::now()).count();
+            failure_diagnostics_[cache_key] = result;
+        };
+
         IDirectInputDevice8W* device = GetOrCreateDevice(binding.device_guid, result);
         if (!device) {
+            cache_failure();
             return result;
         }
 
@@ -349,8 +423,12 @@ class DirectInputPoller {
         cached.valid = ReadState(device, cached.state, result);
         if (!cached.valid) {
             DropDevice(binding.device_guid);
+            cache_failure();
             return result;
         }
+
+        retry_backoff_.RecordSuccess(cache_key);
+        failure_diagnostics_.erase(cache_key);
 
         if (result.diagnostic_stage != InputBindingPollStage::None) {
             result.recovered = true;
@@ -527,8 +605,10 @@ class DirectInputPoller {
 
     IDirectInput8W* direct_input_{nullptr};
     std::mutex mutex_;
+    InputDeviceRetryBackoff retry_backoff_;
     std::unordered_map<std::wstring, IDirectInputDevice8W*> devices_;
     std::unordered_map<std::wstring, CachedDeviceState> state_cache_;
+    std::unordered_map<std::wstring, InputBindingPollResult> failure_diagnostics_;
 };
 
 DirectInputPoller& Poller() {

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -1021,6 +1021,13 @@ double ExtractPosePitchRadians(const XrPosef& pose) {
     return ExtractPitchRadians(ToViewOrientation(pose.orientation));
 }
 
+double ExtractPoseRollRadians(const XrPosef& pose) {
+    const XrQuaternionf& orientation = pose.orientation;
+    return std::atan2(
+        2.0 * (orientation.w * orientation.z + orientation.x * orientation.y),
+        1.0 - 2.0 * (orientation.z * orientation.z + orientation.x * orientation.x));
+}
+
 // Wraps an angle to [-pi, pi]; origin-relative yaw deltas must not jump when
 // the raw yaw crosses the +/-pi seam.
 double WrapRadians(double angle) {
@@ -1181,6 +1188,25 @@ XrPosef ApplyExtraRotationToPose(const XrPosef& pose, float extra_yaw_radians, f
 
 XrPosef IdentityPose() {
     return {{0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f}};
+}
+
+bool IsIdentityPose(const XrPosef& pose) {
+    return NearlyZero(pose.orientation.x) && NearlyZero(pose.orientation.y) &&
+           NearlyZero(pose.orientation.z) && NearlyEqual(pose.orientation.w, 1.0f) &&
+           NearlyZero(pose.position.x) && NearlyZero(pose.position.y) &&
+           NearlyZero(pose.position.z);
+}
+
+// MultiplyPoses uses (local, parent) argument order. Adapt it to conventional
+// lhs * rhs composition for the coordinate-space conjugation helper.
+XrPosef ComposePoses(const XrPosef& lhs, const XrPosef& rhs) {
+    return MultiplyPoses(rhs, lhs);
+}
+
+XrPosef ReexpressPoseDelta(const XrPosef& pose_delta_in_source,
+                           const XrPosef& source_in_target) {
+    return ReexpressPivotPoseDelta(
+        pose_delta_in_source, source_in_target, ComposePoses, InvertPose);
 }
 
 // All generated Pivot movement flows through one pose-offset composition
@@ -2336,6 +2362,8 @@ XrResult OpenXrLayer::EndSession(XrSession session) {
         cached_eye_offset_poses_.clear();
         cached_eye_offsets_display_time_ = 0;
         cached_pivot_pose_deltas_.clear();
+        logged_pivot_space_conversions_.clear();
+        failed_pivot_space_conversions_.clear();
         cached_depth_submission_geometry_.clear();
         cached_quadviews_frames_.Clear();
         last_app_action_sync_time_.reset();
@@ -6479,7 +6507,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         cached_depth_submission_geometry_.clear();
     }
 
-    XrPosef pose_delta = IdentityPose();
+    PivotPoseDeltaFrame pose_delta_frame;
     XrTime matched_time = 0;
 
     const bool pivot_pose_continuity_active =
@@ -6493,14 +6521,15 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     const PivotPoseDeltaSelection pose_delta_selection = resolved_settings_.pivotxr.enabled
         ? ResolvePivotPoseDeltaValue(cached_pivot_pose_deltas_,
                                      frame_end_info->displayTime,
-                                     IdentityPose(),
+                                     PivotPoseDeltaFrame{},
                                      pivot_pose_continuity_active,
                                      &pivotxr_last_matched_pose_delta_,
                                      &pivotxr_consecutive_pose_delta_misses_,
-                                     &pose_delta,
+                                     &pose_delta_frame,
                                      &matched_time)
         : PivotPoseDeltaSelection::None;
     const bool has_pose_delta = pose_delta_selection != PivotPoseDeltaSelection::None;
+    const XrPosef& canonical_pose_delta = pose_delta_frame.canonical_view_pose_delta;
 
     if (pivot_pose_continuity_active) {
         const XrTime nearest_delta_ns = matched_time == 0
@@ -6534,9 +6563,14 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                    << ", pivotEngaged=" << (pivotxr_engaged_ ? "true" : "false")
                    << ", activationGain=" << FormatDiagnosticDouble(pivotxr_activation_gain_)
                    << ", selectedYaw="
-                   << FormatDiagnosticDouble(ExtractPoseYawRadians(pose_delta))
+                   << FormatDiagnosticDouble(ExtractPoseYawRadians(canonical_pose_delta))
                    << ", selectedPitch="
-                   << FormatDiagnosticDouble(ExtractPosePitchRadians(pose_delta));
+                   << FormatDiagnosticDouble(ExtractPosePitchRadians(canonical_pose_delta))
+                   << ", selectedRoll="
+                   << FormatDiagnosticDouble(ExtractPoseRollRadians(canonical_pose_delta))
+                   << ", sourceSpace=" << DescribeSpace(pose_delta_frame.source_space)
+                   << ", cachedSpaceExpressions="
+                   << pose_delta_frame.space_pose_delta_count;
             logger_.Info(stream.str());
         } else if (misses_before_lookup > 0) {
             std::ostringstream stream;
@@ -6551,10 +6585,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         }
     }
     const bool has_non_identity_delta =
-        has_pose_delta && (!NearlyZero(pose_delta.orientation.x) || !NearlyZero(pose_delta.orientation.y) ||
-                           !NearlyZero(pose_delta.orientation.z) || !NearlyEqual(pose_delta.orientation.w, 1.0f) ||
-                           !NearlyZero(pose_delta.position.x) || !NearlyZero(pose_delta.position.y) ||
-                           !NearlyZero(pose_delta.position.z));
+        has_pose_delta && !IsIdentityPose(canonical_pose_delta);
 
     auto find_depth_submission_geometry_for_layer =
         [&](const XrCompositionLayerProjection* projection_layer,
@@ -6723,7 +6754,158 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         return ForwardEndFrame(session, frame_end_info, lock);
     }
 
-    const XrPosef reverse_delta = InvertPose(pose_delta);
+    std::vector<ResolvedPivotSpaceDelta>& resolved_pivot_space_deltas =
+        end_frame_pivot_space_deltas_scratch_;
+    resolved_pivot_space_deltas.clear();
+    resolved_pivot_space_deltas.reserve(frame_end_info->layerCount);
+    uint32_t pivot_space_relation_query_count = 0;
+    uint32_t pivot_space_conversion_count = 0;
+    uint32_t pivot_space_conversion_failure_count = 0;
+    const XrSpace canonical_view_space = internal_view_space_;
+    const XrTime pivot_conversion_time = ClampInternalLocateTime(frame_end_info->displayTime);
+
+    auto resolve_pivot_delta_for_space = [&](XrSpace target_space) -> const ResolvedPivotSpaceDelta& {
+        const auto existing = std::find_if(
+            resolved_pivot_space_deltas.begin(), resolved_pivot_space_deltas.end(),
+            [target_space](const ResolvedPivotSpaceDelta& candidate) {
+                return candidate.space == target_space;
+            });
+        if (existing != resolved_pivot_space_deltas.end()) {
+            return *existing;
+        }
+
+        ResolvedPivotSpaceDelta resolved;
+        resolved.space = target_space;
+        if (!has_pose_delta || !has_non_identity_delta) {
+            resolved.available = has_pose_delta;
+            resolved.mode = has_pose_delta ? "canonical_identity" : "none";
+        } else if (FindPivotPoseDeltaForSpace(pose_delta_frame, target_space, &resolved.forward)) {
+            resolved.available = true;
+            resolved.mode = target_space == pose_delta_frame.source_space
+                ? "source_exact"
+                : "located_views_cache";
+        } else if (target_space == canonical_view_space &&
+                   canonical_view_space != XR_NULL_HANDLE) {
+            resolved.forward = canonical_pose_delta;
+            resolved.available = true;
+            resolved.mode = "canonical_view_exact";
+        } else if (target_space != XR_NULL_HANDLE &&
+                   canonical_view_space != XR_NULL_HANDLE && next_locate_space_) {
+            XrSpaceLocation canonical_in_target{XR_TYPE_SPACE_LOCATION};
+            const auto locate_started = std::chrono::steady_clock::now();
+            // Runtimes may block xrLocateSpace while prediction advances. Do
+            // not hold the layer configuration lock across that downstream
+            // call (notably important for DCS and sequenced Turbo pacing).
+            lock.unlock();
+            resolved.locate_result = next_locate_space_(
+                canonical_view_space, target_space, pivot_conversion_time, &canonical_in_target);
+            lock.lock();
+            resolved.locate_duration_us = std::chrono::duration<double, std::micro>(
+                std::chrono::steady_clock::now() - locate_started).count();
+            resolved.location_flags = canonical_in_target.locationFlags;
+            ++pivot_space_relation_query_count;
+            constexpr XrSpaceLocationFlags kPoseValid =
+                XR_SPACE_LOCATION_ORIENTATION_VALID_BIT | XR_SPACE_LOCATION_POSITION_VALID_BIT;
+            if (XR_SUCCEEDED(resolved.locate_result) &&
+                (canonical_in_target.locationFlags & kPoseValid) == kPoseValid) {
+                resolved.forward = ReexpressPoseDelta(
+                    canonical_pose_delta, canonical_in_target.pose);
+                resolved.available = true;
+                resolved.mode = "canonical_view_locate";
+                CachePivotPoseDeltaForSpace(
+                    pose_delta_frame, target_space, resolved.forward);
+                ++pivot_space_conversion_count;
+            } else {
+                resolved.mode = "conversion_failed";
+                ++pivot_space_conversion_failure_count;
+            }
+        } else {
+            resolved.mode = "conversion_unavailable";
+            ++pivot_space_conversion_failure_count;
+        }
+
+        resolved.non_identity = resolved.available && !IsIdentityPose(resolved.forward);
+        if (resolved.non_identity) {
+            resolved.reverse = InvertPose(resolved.forward);
+        }
+
+        const bool cross_space = target_space != pose_delta_frame.source_space;
+        if (has_non_identity_delta && cross_space && resolved.available) {
+            const bool recovered = failed_pivot_space_conversions_.erase(target_space) > 0;
+            const bool first_observation =
+                logged_pivot_space_conversions_.insert(target_space).second;
+            if (recovered || first_observation) {
+                std::ostringstream stream;
+                stream << "PivotXR space-aware projection correction "
+                       << (recovered ? "recovered" : "active")
+                       << ": frameTime=" << frame_end_info->displayTime
+                       << ", matchedTime=" << matched_time
+                       << ", sourceSpace=" << DescribeSpace(pose_delta_frame.source_space)
+                       << ", projectionSpace=" << DescribeSpace(target_space)
+                       << ", canonicalSpace=" << DescribeSpace(canonical_view_space)
+                       << ", resolution=" << resolved.mode
+                       << ", deltaYaw=" << FormatDiagnosticDouble(ExtractPoseYawRadians(resolved.forward))
+                       << ", deltaPitch=" << FormatDiagnosticDouble(ExtractPosePitchRadians(resolved.forward))
+                       << ", deltaRoll=" << FormatDiagnosticDouble(ExtractPoseRollRadians(resolved.forward))
+                       << ", deltaPosition=(" << FormatDiagnosticDouble(resolved.forward.position.x) << ", "
+                       << FormatDiagnosticDouble(resolved.forward.position.y) << ", "
+                       << FormatDiagnosticDouble(resolved.forward.position.z) << ").";
+                logger_.Info(stream.str());
+            }
+        } else if (has_non_identity_delta && !resolved.available) {
+            const bool first_failure =
+                failed_pivot_space_conversions_.insert(target_space).second;
+            pending_locate_views_diagnostics_ =
+                std::max<uint32_t>(pending_locate_views_diagnostics_, 5);
+            pending_end_frame_diagnostics_ =
+                std::max<uint32_t>(pending_end_frame_diagnostics_, 5);
+            if (first_failure) {
+                std::ostringstream stream;
+                stream << "PivotXR projection-space conversion failed; leaving this projection layer's pose unchanged: "
+                       << "frameTime=" << frame_end_info->displayTime
+                       << ", matchedTime=" << matched_time
+                       << ", sourceSpace=" << DescribeSpace(pose_delta_frame.source_space)
+                       << ", projectionSpace=" << DescribeSpace(target_space)
+                       << ", canonicalSpace=" << DescribeSpace(canonical_view_space)
+                       << ", resolution=" << resolved.mode
+                       << ", locateResult=" << static_cast<int>(resolved.locate_result)
+                       << ", locationFlags="
+                       << FormatHex(static_cast<uint64_t>(resolved.location_flags)) << ".";
+                logger_.Info(stream.str());
+            }
+        }
+
+        if (should_log_end_frame_diagnostic && has_pose_delta) {
+            std::ostringstream stream;
+            stream << "PivotXR projection-space diagnostic: frameTime="
+                   << frame_end_info->displayTime
+                   << ", matchedTime=" << matched_time
+                   << ", sourceSpace=" << DescribeSpace(pose_delta_frame.source_space)
+                   << ", projectionSpace=" << DescribeSpace(target_space)
+                   << ", canonicalSpace=" << DescribeSpace(canonical_view_space)
+                   << ", resolution=" << resolved.mode
+                   << ", available=" << resolved.available
+                   << ", nonIdentity=" << resolved.non_identity
+                   << ", locateResult=" << static_cast<int>(resolved.locate_result)
+                   << ", locationFlags=" << FormatHex(static_cast<uint64_t>(resolved.location_flags))
+                   << ", locateDurationUs=" << FormatDiagnosticDouble(resolved.locate_duration_us)
+                   << ", forwardQuat=(" << FormatDiagnosticDouble(resolved.forward.orientation.x) << ", "
+                   << FormatDiagnosticDouble(resolved.forward.orientation.y) << ", "
+                   << FormatDiagnosticDouble(resolved.forward.orientation.z) << ", "
+                   << FormatDiagnosticDouble(resolved.forward.orientation.w) << ")"
+                   << ", forwardYaw=" << FormatDiagnosticDouble(ExtractPoseYawRadians(resolved.forward))
+                   << ", forwardPitch=" << FormatDiagnosticDouble(ExtractPosePitchRadians(resolved.forward))
+                   << ", forwardRoll=" << FormatDiagnosticDouble(ExtractPoseRollRadians(resolved.forward))
+                   << ", forwardPosition=(" << FormatDiagnosticDouble(resolved.forward.position.x) << ", "
+                   << FormatDiagnosticDouble(resolved.forward.position.y) << ", "
+                   << FormatDiagnosticDouble(resolved.forward.position.z) << ")";
+            logger_.Debug(stream.str());
+        }
+
+        resolved_pivot_space_deltas.push_back(std::move(resolved));
+        return resolved_pivot_space_deltas.back();
+    };
+
     std::vector<std::vector<XrCompositionLayerProjectionView>>& adjusted_projection_views =
         end_frame_projection_views_scratch_;
     std::vector<XrCompositionLayerProjection>& adjusted_projection_layers = end_frame_projection_layers_scratch_;
@@ -6745,11 +6927,13 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     auto append_projection_layer = [&](const XrCompositionLayerProjection* projection_layer,
                                        uint32_t first_view,
                                        uint32_t view_count,
+                                       const XrPosef& reverse_delta,
+                                       bool has_layer_pose_delta,
                                        XrCompositionLayerFlags extra_layer_flags = 0) {
         adjusted_projection_views.emplace_back(projection_layer->views + first_view,
                                                projection_layer->views + first_view + view_count);
         for (XrCompositionLayerProjectionView& projection_view : adjusted_projection_views.back()) {
-            if (has_non_identity_delta) {
+            if (has_layer_pose_delta) {
                 projection_view.pose = MultiplyPoses(projection_view.pose, reverse_delta);
             }
         }
@@ -6760,7 +6944,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                 first_view,
                 *layer_geometry,
                 reverse_delta,
-                has_non_identity_delta);
+                has_layer_pose_delta);
         }
 
         adjusted_projection_layers.push_back(*projection_layer);
@@ -6787,6 +6971,8 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
             adjusted_layers.push_back(base_header);
             continue;
         }
+        const ResolvedPivotSpaceDelta& layer_pivot_delta =
+            resolve_pivot_delta_for_space(projection_layer->space);
 
         for (uint32_t view_index = 0; view_index < projection_layer->viewCount; ++view_index) {
             const XrSwapchain referenced_swapchain = projection_layer->views[view_index].subImage.swapchain;
@@ -6804,8 +6990,8 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
             adjusted_projection_layers.emplace_back();
             if (ComposeQuadViewsD3D11(projection_layer,
                                       frame_end_info->displayTime,
-                                      reverse_delta,
-                                      has_non_identity_delta,
+                                      layer_pivot_delta.reverse,
+                                      layer_pivot_delta.non_identity,
                                       &adjusted_projection_layers.back(),
                                       &adjusted_projection_views.back())) {
                 if (const DepthSubmissionGeometry* layer_geometry =
@@ -6814,8 +7000,8 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                         std::span<XrCompositionLayerProjectionView>(adjusted_projection_views.back()),
                         0,
                         *layer_geometry,
-                        reverse_delta,
-                        has_non_identity_delta);
+                        layer_pivot_delta.reverse,
+                        layer_pivot_delta.non_identity);
                 }
                 adjusted_layers.push_back(
                     reinterpret_cast<const XrCompositionLayerBaseHeader*>(&adjusted_projection_layers.back()));
@@ -6834,14 +7020,24 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
             // reversed painter ordering while we build the native compositor.
             constexpr XrCompositionLayerFlags kFovealBlendFlags =
                 XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT | XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
-            append_projection_layer(projection_layer, 2, 2, kFovealBlendFlags);
-            append_projection_layer(projection_layer, 0, 2);
-            append_projection_layer(projection_layer, 2, 2, kFovealBlendFlags);
+            append_projection_layer(projection_layer, 2, 2,
+                                    layer_pivot_delta.reverse,
+                                    layer_pivot_delta.non_identity,
+                                    kFovealBlendFlags);
+            append_projection_layer(projection_layer, 0, 2,
+                                    layer_pivot_delta.reverse,
+                                    layer_pivot_delta.non_identity);
+            append_projection_layer(projection_layer, 2, 2,
+                                    layer_pivot_delta.reverse,
+                                    layer_pivot_delta.non_identity,
+                                    kFovealBlendFlags);
             ++split_quad_projection_layer_count;
             continue;
         }
 
-        append_projection_layer(projection_layer, 0, projection_layer->viewCount);
+        append_projection_layer(projection_layer, 0, projection_layer->viewCount,
+                                layer_pivot_delta.reverse,
+                                layer_pivot_delta.non_identity);
         // Varjo compatible quadviews: sharpen the runtime's focus views in place when
         // foveate_sharpness > 0. No-op (pure passthrough) when sharpness is 0 or the
         // layer is not a native quad projection.
@@ -6854,12 +7050,6 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     adjusted_frame_end_info.layerCount = static_cast<uint32_t>(adjusted_layers.size());
     adjusted_frame_end_info.layers = adjusted_layers.data();
     if (should_log_end_frame_diagnostic) {
-        const ViewOrientation delta_orientation{
-            pose_delta.orientation.x,
-            pose_delta.orientation.y,
-            pose_delta.orientation.z,
-            pose_delta.orientation.w,
-        };
         std::ostringstream stream;
         stream << "EndFrame projection rewrite applied: frameTime=" << frame_end_info->displayTime
                << ", matchedTime=" << matched_time
@@ -6867,8 +7057,19 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
                << ", depthAnchorMatchedTime=" << matched_depth_submission_time
                << ", depthAnchorMatchedDeltaNs="
                << (matched_depth_submission_time - frame_end_info->displayTime)
-               << ", poseDeltaYaw=" << FormatDiagnosticDouble(ExtractYawRadians(delta_orientation))
-               << ", poseDeltaPitch=" << FormatDiagnosticDouble(ExtractPitchRadians(delta_orientation))
+               << ", canonicalSpace=" << DescribeSpace(canonical_view_space)
+               << ", sourceSpace=" << DescribeSpace(pose_delta_frame.source_space)
+               << ", canonicalDeltaYaw="
+               << FormatDiagnosticDouble(ExtractPoseYawRadians(canonical_pose_delta))
+               << ", canonicalDeltaPitch="
+               << FormatDiagnosticDouble(ExtractPosePitchRadians(canonical_pose_delta))
+               << ", canonicalDeltaRoll="
+               << FormatDiagnosticDouble(ExtractPoseRollRadians(canonical_pose_delta))
+               << ", cachedSpaceExpressions=" << pose_delta_frame.space_pose_delta_count
+               << ", resolvedProjectionSpaces=" << resolved_pivot_space_deltas.size()
+               << ", spaceRelationQueries=" << pivot_space_relation_query_count
+               << ", spaceConversions=" << pivot_space_conversion_count
+               << ", spaceConversionFailures=" << pivot_space_conversion_failure_count
                << ", projectionLayers=" << corrected_projection_layer_count
                << ", projectionViews=" << corrected_projection_view_count
                << ", depthAnchorRestoredViews=" << depth_anchor_restored_view_count
@@ -7194,7 +7395,8 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
     if (resolved_settings_.pivotxr.enabled && !has_logged_pivotxr_spike_mode_) {
         std::ostringstream stream;
         stream << "PivotXR enabled; activationState=" << (pivotxr_active ? "engaged" : "idle")
-               << "; quad-view sessions use stereo eye-pose recomposition.";
+               << "; canonicalFrame=VIEW(internal); spaceAwareProjectionCorrection=enabled; "
+                  "quad-view sessions use stereo eye-pose recomposition.";
         for (const PivotXrResolvedProfile& profile : resolved_settings_.pivotxr.profiles) {
             if (profile.always_active) {
                 stream << " '" << profile.name << "' engages automatically";
@@ -7222,6 +7424,9 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
     // call, otherwise they would capture an identity origin.
     const XrTime internal_locate_time =
         view_locate_info ? ClampInternalLocateTime(view_locate_info->displayTime) : 0;
+    bool pivot_frame_reused = false;
+    bool pivot_frame_cached = false;
+    XrSpace pivot_frame_source_space = XR_NULL_HANDLE;
 
     if (pivotxr_origin_capture_pending_ && resolved_settings_.pivotxr.enabled &&
         internal_view_space_ != XR_NULL_HANDLE && pivot_drive_query) {
@@ -7244,7 +7449,11 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                           << " pitch=" << FormatDiagnosticDouble(origin.pitch_radians)
                           << " rad, position=(" << FormatDiagnosticDouble(origin.pose.position.x) << ", "
                           << FormatDiagnosticDouble(origin.pose.position.y) << ", "
-                          << FormatDiagnosticDouble(origin.pose.position.z) << ").";
+                          << FormatDiagnosticDouble(origin.pose.position.z) << ")"
+                          << ", frameTime=" << origin.capture_time
+                          << ", baseSpace=" << DescribeSpace(view_locate_info->space)
+                          << ", locationFlags="
+                          << FormatHex(static_cast<uint64_t>(origin.location_flags)) << ".";
             logger_.Info(origin_stream.str());
         }
     }
@@ -7260,15 +7469,32 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
             internal_view_space_, view_locate_info->space, internal_locate_time, &pivot_view_location);
         if (XR_SUCCEEDED(pivot_result)) {
             runtime_view_pose = pivot_view_location.pose;
-            pivot_result = ApplyPivotToLocatedSpace(internal_view_space_,
-                                                     view_locate_info->space,
-                                                     internal_locate_time,
-                                                     pivotxr_active,
-                                                     &pivot_view_location,
-                                                     &applied_extra_yaw_radians,
-                                                     &applied_extra_pitch_radians,
-                                                     &applied_pose_delta,
-                                                     true);
+            const auto existing_frame =
+                cached_pivot_pose_deltas_.find(view_locate_info->displayTime);
+            if (existing_frame != cached_pivot_pose_deltas_.end()) {
+                // Repeated world-space queries for one predicted display time
+                // reuse the first logical Pivot update. VIEW-in-base is already
+                // available from the runtime locate above, so the canonical
+                // VIEW-space delta can be expressed in this base without an
+                // additional runtime call.
+                applied_pose_delta = ReexpressPoseDelta(
+                    existing_frame->second.canonical_view_pose_delta, runtime_view_pose);
+                pivot_view_location.pose = MultiplyPoses(runtime_view_pose, applied_pose_delta);
+                applied_extra_yaw_radians = pivot_diagnostic_.eased_extra_yaw_radians;
+                applied_extra_pitch_radians = pivot_diagnostic_.eased_extra_pitch_radians;
+                pivot_frame_reused = true;
+                pivot_frame_source_space = existing_frame->second.source_space;
+            } else {
+                pivot_result = ApplyPivotToLocatedSpace(internal_view_space_,
+                                                         view_locate_info->space,
+                                                         internal_locate_time,
+                                                         pivotxr_active,
+                                                         &pivot_view_location,
+                                                         &applied_extra_yaw_radians,
+                                                         &applied_extra_pitch_radians,
+                                                         &applied_pose_delta,
+                                                         true);
+            }
         }
         if (XR_SUCCEEDED(pivot_result)) {
             const auto ensure_eye_offsets = [&](XrViewConfigurationType offset_view_configuration,
@@ -7285,17 +7511,26 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                 return derived || EnsureEyeOffsets(
                                       session, offset_view_configuration, internal_locate_time, offset_count);
             };
-            const bool identity_pose_delta =
-                NearlyZero(applied_pose_delta.orientation.x) &&
-                NearlyZero(applied_pose_delta.orientation.y) &&
-                NearlyZero(applied_pose_delta.orientation.z) &&
-                NearlyEqual(applied_pose_delta.orientation.w, 1.0f) &&
-                NearlyZero(applied_pose_delta.position.x) && NearlyZero(applied_pose_delta.position.y) &&
-                NearlyZero(applied_pose_delta.position.z);
+            auto cache_applied_pose_delta = [&](const XrPosef& pose_delta) {
+                if (pivot_frame_reused) {
+                    auto frame = cached_pivot_pose_deltas_.find(view_locate_info->displayTime);
+                    if (frame != cached_pivot_pose_deltas_.end()) {
+                        CachePivotPoseDeltaForSpace(
+                            frame->second, view_locate_info->space, pose_delta);
+                    }
+                    return;
+                }
+                pivot_frame_cached = CachePivotPoseDelta(view_locate_info->displayTime,
+                                                          view_locate_info->space,
+                                                          pose_delta,
+                                                          runtime_view_pose);
+                pivot_frame_source_space = view_locate_info->space;
+            };
+            const bool identity_pose_delta = IsIdentityPose(applied_pose_delta);
             if (identity_pose_delta) {
                 pivot_diagnostic_.recomposition_mode = "identity";
                 pivot_diagnostic_.has_eye_offsets = false;
-                CachePivotPoseDelta(view_locate_info->displayTime, IdentityPose());
+                cache_applied_pose_delta(IdentityPose());
             } else if (IsQuadViewConfiguration(view_configuration_type) &&
                        ensure_eye_offsets(varjo_compatible_quadviews_active_
                                               ? view_configuration_type
@@ -7303,7 +7538,7 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                                           varjo_compatible_quadviews_active_ ? count : 2)) {
                 pivot_diagnostic_.recomposition_mode =
                     varjo_compatible_quadviews_active_ ? "quad_native_eye_offsets" : "quad_from_stereo_eye_offsets";
-                CachePivotPoseDelta(view_locate_info->displayTime, applied_pose_delta);
+                cache_applied_pose_delta(applied_pose_delta);
                 for (uint32_t i = 0; i < count; ++i) {
                     // Native: one offset per view. Emulation: focus views (2/3) reuse the
                     // same eye offset as their peripheral counterpart (i % 2).
@@ -7321,7 +7556,7 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
             } else if (!IsQuadViewConfiguration(view_configuration_type) &&
                        ensure_eye_offsets(view_configuration_type, count)) {
                 pivot_diagnostic_.recomposition_mode = "stereo_eye_offsets";
-                CachePivotPoseDelta(view_locate_info->displayTime, applied_pose_delta);
+                cache_applied_pose_delta(applied_pose_delta);
                 for (uint32_t i = 0; i < count; ++i) {
                     const XrPosef recomposed_pose =
                         MultiplyPoses(cached_eye_offset_poses_[i], pivot_view_location.pose);
@@ -7336,7 +7571,7 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
             } else {
                 pivot_diagnostic_.recomposition_mode = "eye_offset_capture_failed";
                 pivot_diagnostic_.has_eye_offsets = false;
-                CachePivotPoseDelta(view_locate_info->displayTime, IdentityPose());
+                cache_applied_pose_delta(IdentityPose());
             }
             // LocateSpaceWithPivot owns the steady-state smoothed angles and the
             // activation envelope; do not write the eased output back onto them.
@@ -7479,6 +7714,12 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                    << ", pivotExtraYawRadians=" << FormatDiagnosticDouble(pivotxr_smoothed_extra_yaw_radians_)
                    << ", pivotExtraPitchRadians=" << FormatDiagnosticDouble(pivotxr_smoothed_extra_pitch_radians_)
                    << ", pivotActivationGain=" << FormatDiagnosticDouble(pivotxr_activation_gain_)
+                   << ", pivotDriveQuery=" << pivot_drive_query
+                   << ", pivotFrameReused=" << pivot_frame_reused
+                   << ", pivotFrameCached=" << pivot_frame_cached
+                   << ", pivotBaseSpace="
+                   << DescribeSpace(view_locate_info ? view_locate_info->space : XR_NULL_HANDLE)
+                   << ", pivotFrameSourceSpace=" << DescribeSpace(pivot_frame_source_space)
                    << ", leftYawDelta=" << FormatDiagnosticDouble(left_yaw_delta)
                    << ", rightYawDelta=" << FormatDiagnosticDouble(right_yaw_delta)
                    << ", leftInsetYawDelta=" << FormatDiagnosticDouble(left_inset_yaw_delta)
@@ -7533,6 +7774,12 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                    << ", recomposition=" << pivot_diagnostic_.recomposition_mode
                    << ", pivotActive=" << pivot_diagnostic_.pivot_active
                    << ", envelopeEngaged=" << pivotxr_envelope_engaged
+                   << ", driveQuery=" << pivot_drive_query
+                   << ", logicalFrameReused=" << pivot_frame_reused
+                   << ", logicalFrameCached=" << pivot_frame_cached
+                   << ", locateBaseSpace="
+                   << DescribeSpace(view_locate_info ? view_locate_info->space : XR_NULL_HANDLE)
+                   << ", logicalFrameSourceSpace=" << DescribeSpace(pivot_frame_source_space)
                    << ", viewPoseFresh=" << view_pose_fresh
                    << ", rawYaw=" << FormatDiagnosticDouble(pivot_diagnostic_.raw_yaw_radians)
                    << ", rawPitch=" << FormatDiagnosticDouble(pivot_diagnostic_.raw_pitch_radians)
@@ -7599,6 +7846,31 @@ XrResult OpenXrLayer::DestroySpace(XrSpace space) {
     const XrResult result = next_destroy_space_(space);
     if (XR_SUCCEEDED(result)) {
         std::scoped_lock lock(mutex_);
+        const auto remove_space_from_frame = [space](PivotPoseDeltaFrame& frame) {
+            for (std::size_t index = 0; index < frame.space_pose_delta_count;) {
+                if (frame.space_pose_deltas[index].space != space) {
+                    ++index;
+                    continue;
+                }
+                for (std::size_t move = index + 1;
+                     move < frame.space_pose_delta_count; ++move) {
+                    frame.space_pose_deltas[move - 1] = frame.space_pose_deltas[move];
+                }
+                --frame.space_pose_delta_count;
+            }
+            if (frame.source_space == space) {
+                frame.source_space = XR_NULL_HANDLE;
+            }
+        };
+        for (auto& [time, frame] : cached_pivot_pose_deltas_) {
+            (void)time;
+            remove_space_from_frame(frame);
+        }
+        if (pivotxr_last_matched_pose_delta_) {
+            remove_space_from_frame(*pivotxr_last_matched_pose_delta_);
+        }
+        logged_pivot_space_conversions_.erase(space);
+        failed_pivot_space_conversions_.erase(space);
         tracked_view_spaces_.erase(space);
         tracked_local_spaces_.erase(space);
         tracked_stage_spaces_.erase(space);
@@ -8242,6 +8514,8 @@ void OpenXrLayer::ResetSessionState() {
     cached_eye_offset_poses_.clear();
     cached_eye_offsets_display_time_ = 0;
     cached_pivot_pose_deltas_.clear();
+    logged_pivot_space_conversions_.clear();
+    failed_pivot_space_conversions_.clear();
     cached_depth_submission_geometry_.clear();
     cached_quadviews_frames_.Clear();
     last_app_action_sync_time_.reset();
@@ -8758,6 +9032,8 @@ void OpenXrLayer::DestroyInternalReferenceSpaces() {
         cached_eye_offset_poses_.clear();
         cached_eye_offsets_display_time_ = 0;
         cached_pivot_pose_deltas_.clear();
+        logged_pivot_space_conversions_.clear();
+        failed_pivot_space_conversions_.clear();
         cached_depth_submission_geometry_.clear();
         cached_quadviews_frames_.Clear();
         return;
@@ -8787,6 +9063,8 @@ void OpenXrLayer::DestroyInternalReferenceSpaces() {
     cached_eye_offset_poses_.clear();
     cached_eye_offsets_display_time_ = 0;
     cached_pivot_pose_deltas_.clear();
+    logged_pivot_space_conversions_.clear();
+    failed_pivot_space_conversions_.clear();
     cached_depth_submission_geometry_.clear();
     cached_quadviews_frames_.Clear();
 }
@@ -9006,20 +9284,81 @@ bool OpenXrLayer::EnsureEyeOffsets(XrSession session,
     return true;
 }
 
-void OpenXrLayer::CachePivotPoseDelta(XrTime time, const XrPosef& pose_delta) {
-    CachePivotPoseDeltaValue(cached_pivot_pose_deltas_, time, pose_delta);
+bool OpenXrLayer::CachePivotPoseDelta(XrTime time,
+                                      XrSpace source_space,
+                                      const XrPosef& source_pose_delta,
+                                      const XrPosef& view_pose_in_source) {
+    if (time == 0 || source_space == XR_NULL_HANDLE) {
+        return false;
+    }
+
+    PivotPoseDeltaFrame frame;
+    frame.source_space = source_space;
+    // The runtime has already given us VIEW-in-source for the Pivot drive.
+    // Its inverse is source-in-VIEW, so this conjugation produces a durable
+    // frame-canonical delta without another runtime locate.
+    frame.canonical_view_pose_delta =
+        ReexpressPoseDelta(source_pose_delta, InvertPose(view_pose_in_source));
+    frame.space_pose_deltas[0] = {source_space, source_pose_delta};
+    frame.space_pose_delta_count = 1;
+    return CachePivotPoseDeltaValue(cached_pivot_pose_deltas_, time, frame);
 }
 
-bool OpenXrLayer::FindPivotPoseDelta(XrTime time, XrPosef* pose_delta, XrTime* matched_time) const {
-    return FindPivotPoseDeltaValue(cached_pivot_pose_deltas_,
-                                   time,
-                                   IdentityPose(),
-                                   pose_delta,
-                                   matched_time);
+bool OpenXrLayer::FindPivotPoseDeltaForSpace(const PivotPoseDeltaFrame& frame,
+                                             XrSpace space,
+                                             XrPosef* pose_delta) const {
+    if (!pose_delta || space == XR_NULL_HANDLE) {
+        return false;
+    }
+    for (std::size_t index = 0; index < frame.space_pose_delta_count; ++index) {
+        if (frame.space_pose_deltas[index].space == space) {
+            *pose_delta = frame.space_pose_deltas[index].pose_delta;
+            return true;
+        }
+    }
+    return false;
+}
+
+void OpenXrLayer::CachePivotPoseDeltaForSpace(PivotPoseDeltaFrame& frame,
+                                              XrSpace space,
+                                              const XrPosef& pose_delta) const {
+    if (space == XR_NULL_HANDLE) {
+        return;
+    }
+    for (std::size_t index = 0; index < frame.space_pose_delta_count; ++index) {
+        if (frame.space_pose_deltas[index].space == space) {
+            frame.space_pose_deltas[index].pose_delta = pose_delta;
+            return;
+        }
+    }
+    if (frame.space_pose_delta_count < frame.space_pose_deltas.size()) {
+        frame.space_pose_deltas[frame.space_pose_delta_count++] = {space, pose_delta};
+    }
 }
 
 void OpenXrLayer::PrunePivotPoseDeltas(XrTime time) {
     PrunePivotPoseDeltaValues(cached_pivot_pose_deltas_, time);
+}
+
+std::string OpenXrLayer::DescribeSpace(XrSpace space) const {
+    std::string label = "UNKNOWN";
+    if (space == XR_NULL_HANDLE) {
+        return "NULL";
+    }
+    if (space == internal_view_space_) {
+        label = "VIEW(internal)";
+    } else if (space == internal_local_space_) {
+        label = "LOCAL(internal)";
+    } else if (space == internal_stage_space_) {
+        label = "STAGE(internal)";
+    } else if (tracked_view_spaces_.contains(space)) {
+        label = "VIEW";
+    } else if (tracked_local_spaces_.contains(space)) {
+        label = "LOCAL";
+    } else if (tracked_stage_spaces_.contains(space)) {
+        label = "STAGE";
+    }
+    return label + "(" + FormatHex(reinterpret_cast<uintptr_t>(space)) + ")";
 }
 
 void OpenXrLayer::CacheDepthSubmissionGeometry(

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -2337,7 +2337,7 @@ XrResult OpenXrLayer::EndSession(XrSession session) {
         cached_eye_offsets_display_time_ = 0;
         cached_pivot_pose_deltas_.clear();
         cached_depth_submission_geometry_.clear();
-        cached_quadviews_fovs_.clear();
+        cached_quadviews_frames_.Clear();
         last_app_action_sync_time_.reset();
         last_eye_gaze_self_sync_time_.reset();
         quadviews_smoothed_focus_yaw_radians_ = 0.0;
@@ -3913,9 +3913,22 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         return false;
     }
 
-    std::array<XrFovf, 4> cached_fovs{};
+    QuadViewsFrameState cached_frame{};
     XrTime matched_quadviews_fov_time = 0;
-    const bool has_cached_fovs = FindQuadViewsFovs(display_time, &cached_fovs, &matched_quadviews_fov_time);
+    const bool has_cached_fovs =
+        FindQuadViewsFrame(display_time, &cached_frame, &matched_quadviews_fov_time);
+    QuadViewsGazeDiagnostic gaze_diagnostic{};
+    if (has_cached_fovs) {
+        gaze_diagnostic = cached_frame.gaze;
+    } else if (quadviews_raw_focus_valid_ && quadviews_raw_focus_time_ == display_time) {
+        // A missing FOV cache is unusual, but retain an exact-time fallback for
+        // startup frames instead of pairing the submission with a newer locate.
+        gaze_diagnostic.valid = true;
+        gaze_diagnostic.raw_yaw_radians = quadviews_raw_focus_yaw_radians_;
+        gaze_diagnostic.raw_pitch_radians = quadviews_raw_focus_pitch_radians_;
+        gaze_diagnostic.smoothed_yaw_radians = quadviews_smoothed_focus_yaw_radians_;
+        gaze_diagnostic.smoothed_pitch_radians = quadviews_smoothed_focus_pitch_radians_;
+    }
 
     struct SavedD3D11State {
         ID3D11RenderTargetView* render_targets[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT]{};
@@ -4244,8 +4257,9 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         context->PSSetShaderResources(0, 2, resources);
         context->PSSetSamplers(0, 1, &d3d11_quadviews_compositor_.sampler);
 
-        const XrFovf& full_fov = has_cached_fovs ? cached_fovs[eye] : source_layer->views[eye].fov;
-        const XrFovf& focus_fov = has_cached_fovs ? cached_fovs[eye + 2] : source_layer->views[eye + 2].fov;
+        const XrFovf& full_fov = has_cached_fovs ? cached_frame.fovs[eye] : source_layer->views[eye].fov;
+        const XrFovf& focus_fov =
+            has_cached_fovs ? cached_frame.fovs[eye + 2] : source_layer->views[eye + 2].fov;
         const XrSwapchainSubImage& peripheral_sub_image = source_layer->views[eye].subImage;
         const XrSwapchainSubImage& focus_sub_image = source_layer->views[eye + 2].subImage;
         const uint32_t focus_content_width =
@@ -4263,9 +4277,7 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
 
         const bool eye_tracking_mode =
             resolved_settings_.quadviews.tracking_mode == QuadViewsTrackingMode::Eye;
-        const XrTime diagnostic_time = has_cached_fovs ? matched_quadviews_fov_time : display_time;
-        const bool raw_gaze_valid = eye_tracking_mode && quadviews_raw_focus_valid_ &&
-                                    quadviews_raw_focus_time_ == diagnostic_time;
+        const bool raw_gaze_valid = eye_tracking_mode && gaze_diagnostic.valid;
         constants.diagnostic_params[0] = quadviews_diagnostic_visualization_enabled_ ? 1.0f : 0.0f;
         constants.diagnostic_params[1] = eye_tracking_mode ? 1.0f : 0.0f;
         constants.diagnostic_params[2] = raw_gaze_valid ? 1.0f : 0.0f;
@@ -4273,9 +4285,9 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
         constants.output_texel[1] = 1.0f / static_cast<float>(std::max<uint32_t>(1, target.height));
 
         const std::array<float, 2> raw_gaze_uv = ProjectViewAnglesToUv(
-            full_fov, quadviews_raw_focus_yaw_radians_, quadviews_raw_focus_pitch_radians_);
+            full_fov, gaze_diagnostic.raw_yaw_radians, gaze_diagnostic.raw_pitch_radians);
         const std::array<float, 2> smoothed_gaze_uv = ProjectViewAnglesToUv(
-            full_fov, quadviews_smoothed_focus_yaw_radians_, quadviews_smoothed_focus_pitch_radians_);
+            full_fov, gaze_diagnostic.smoothed_yaw_radians, gaze_diagnostic.smoothed_pitch_radians);
         const std::array<float, 2> head_center_uv = ProjectViewAnglesToUv(full_fov, 0.0, 0.0);
         const std::array<float, 2> configured_offset_uv = ProjectViewAnglesToUv(
             full_fov,
@@ -4517,7 +4529,7 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
             (*composed_views)[eye].pose = MultiplyPoses((*composed_views)[eye].pose, reverse_delta);
         }
         if (has_cached_fovs) {
-            (*composed_views)[eye].fov = cached_fovs[eye];
+            (*composed_views)[eye].fov = cached_frame.fovs[eye];
         }
         QuadViewsCompositionTarget& target = d3d11_quadviews_compositor_.targets[eye];
         (*composed_views)[eye].subImage.swapchain = target.swapchain;
@@ -6400,7 +6412,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     if (!resolved_settings_.core.enabled) {
         cached_pivot_pose_deltas_.clear();
         cached_depth_submission_geometry_.clear();
-        cached_quadviews_fovs_.clear();
+        cached_quadviews_frames_.Clear();
         pivotxr_smoothed_extra_yaw_radians_ = 0.0;
         pivotxr_smoothed_extra_pitch_radians_ = 0.0;
         pivotxr_yaw_step_ = 0;
@@ -6413,7 +6425,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
         PrunePivotPoseDeltas(frame_end_info->displayTime);
         PruneDepthSubmissionGeometry(frame_end_info->displayTime);
-        PruneQuadViewsFovs(frame_end_info->displayTime);
+        PruneQuadViewsFrames(frame_end_info->displayTime);
         if (XR_FAILED(release_result)) {
             return release_result;
         }
@@ -6703,7 +6715,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
         const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
         PrunePivotPoseDeltas(frame_end_info->displayTime);
         PruneDepthSubmissionGeometry(frame_end_info->displayTime);
-        PruneQuadViewsFovs(frame_end_info->displayTime);
+        PruneQuadViewsFrames(frame_end_info->displayTime);
         if (XR_FAILED(release_result)) {
             return release_result;
         }
@@ -6875,7 +6887,7 @@ XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_en
     const XrResult release_result = FlushDeferredSwapchainReleasesLocked("end frame");
     PrunePivotPoseDeltas(frame_end_info->displayTime);
     PruneDepthSubmissionGeometry(frame_end_info->displayTime);
-    PruneQuadViewsFovs(frame_end_info->displayTime);
+    PruneQuadViewsFrames(frame_end_info->displayTime);
     if (XR_FAILED(release_result)) {
         return release_result;
     }
@@ -7083,8 +7095,16 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
                                   uint32_t* view_count_output,
                                   XrView* views) {
     bool synthesized_quad_views = false;
+    QuadViewsGazeDiagnostic gaze_diagnostic{};
     const XrResult result = LocateRuntimeViews(
-        session, view_locate_info, view_state, view_capacity_input, view_count_output, views, &synthesized_quad_views);
+        session,
+        view_locate_info,
+        view_state,
+        view_capacity_input,
+        view_count_output,
+        views,
+        &synthesized_quad_views,
+        &gaze_diagnostic);
 
     if (XR_FAILED(result) || !views || !view_count_output) {
         return result;
@@ -7375,7 +7395,8 @@ XrResult OpenXrLayer::LocateViews(XrSession session,
         views[i].fov.angleDown = static_cast<float>(adjusted_views[i].fov.angle_down);
     }
     if (view_locate_info && IsQuadViewConfiguration(view_configuration_type) && count >= 4) {
-        CacheQuadViewsFovs(view_locate_info->displayTime, std::span<const XrView>(views, count));
+        CacheQuadViewsFrame(
+            view_locate_info->displayTime, std::span<const XrView>(views, count), gaze_diagnostic);
     }
 
     const XrTime locate_time = view_locate_info ? view_locate_info->displayTime : 0;
@@ -8222,7 +8243,7 @@ void OpenXrLayer::ResetSessionState() {
     cached_eye_offsets_display_time_ = 0;
     cached_pivot_pose_deltas_.clear();
     cached_depth_submission_geometry_.clear();
-    cached_quadviews_fovs_.clear();
+    cached_quadviews_frames_.Clear();
     last_app_action_sync_time_.reset();
     last_eye_gaze_self_sync_time_.reset();
     ResetSwapchainState();
@@ -8738,7 +8759,7 @@ void OpenXrLayer::DestroyInternalReferenceSpaces() {
         cached_eye_offsets_display_time_ = 0;
         cached_pivot_pose_deltas_.clear();
         cached_depth_submission_geometry_.clear();
-        cached_quadviews_fovs_.clear();
+        cached_quadviews_frames_.Clear();
         return;
     }
 
@@ -8767,7 +8788,7 @@ void OpenXrLayer::DestroyInternalReferenceSpaces() {
     cached_eye_offsets_display_time_ = 0;
     cached_pivot_pose_deltas_.clear();
     cached_depth_submission_geometry_.clear();
-    cached_quadviews_fovs_.clear();
+    cached_quadviews_frames_.Clear();
 }
 
 XrResult OpenXrLayer::CreateVarjoNativeFoveationResources(XrSession session) {
@@ -9184,67 +9205,37 @@ uint32_t OpenXrLayer::RestoreDepthSubmissionGeometry(
     return restored_views;
 }
 
-void OpenXrLayer::CacheQuadViewsFovs(XrTime time, std::span<const XrView> views) {
+void OpenXrLayer::CacheQuadViewsFrame(XrTime time,
+                                      std::span<const XrView> views,
+                                      const QuadViewsGazeDiagnostic& gaze) {
     if (time == 0 || views.size() < 4) {
         return;
     }
 
-    std::array<XrFovf, 4> fovs{};
-    for (uint32_t i = 0; i < fovs.size(); ++i) {
-        fovs[i] = views[i].fov;
+    QuadViewsFrameState frame;
+    for (uint32_t i = 0; i < frame.fovs.size(); ++i) {
+        frame.fovs[i] = views[i].fov;
     }
-    cached_quadviews_fovs_[time] = fovs;
-    while (cached_quadviews_fovs_.size() > kMaxCachedQuadViewsFovFrames) {
-        cached_quadviews_fovs_.erase(cached_quadviews_fovs_.begin());
-    }
+    frame.gaze = gaze;
+    cached_quadviews_frames_.Store(time, frame, kMaxCachedQuadViewsFovFrames);
 }
 
-bool OpenXrLayer::FindQuadViewsFovs(XrTime time, std::array<XrFovf, 4>* fovs, XrTime* matched_time) const {
-    if (!fovs || !matched_time) {
+bool OpenXrLayer::FindQuadViewsFrame(XrTime time,
+                                     QuadViewsFrameState* frame,
+                                     XrTime* matched_time) const {
+    if (!frame || !matched_time) {
         return false;
     }
 
-    if (cached_quadviews_fovs_.empty()) {
-        *matched_time = 0;
-        return false;
-    }
-
-    auto exact = cached_quadviews_fovs_.find(time);
-    if (exact != cached_quadviews_fovs_.end()) {
-        *fovs = exact->second;
-        *matched_time = exact->first;
-        return true;
-    }
-
-    auto upper = cached_quadviews_fovs_.lower_bound(time);
-    std::map<XrTime, std::array<XrFovf, 4>>::const_iterator best;
-    if (upper == cached_quadviews_fovs_.begin()) {
-        best = upper;
-    } else if (upper == cached_quadviews_fovs_.end()) {
-        best = std::prev(upper);
-    } else {
-        auto lower = std::prev(upper);
-        best = (time - lower->first <= upper->first - time) ? lower : upper;
-    }
-
-    const XrTime match_delta = best->first > time ? best->first - time : time - best->first;
-    if (match_delta > kMaxQuadViewsFovMatchWindow) {
-        *matched_time = best->first;
-        return false;
-    }
-
-    *fovs = best->second;
-    *matched_time = best->first;
-    return true;
+    std::int64_t cache_matched_time = 0;
+    const bool found = cached_quadviews_frames_.FindNearest(
+        time, kMaxQuadViewsFovMatchWindow, frame, &cache_matched_time);
+    *matched_time = cache_matched_time;
+    return found;
 }
 
-void OpenXrLayer::PruneQuadViewsFovs(XrTime time) {
-    auto keep_from = cached_quadviews_fovs_.upper_bound(time);
-    if (keep_from == cached_quadviews_fovs_.begin()) {
-        return;
-    }
-
-    cached_quadviews_fovs_.erase(cached_quadviews_fovs_.begin(), keep_from);
+void OpenXrLayer::PruneQuadViewsFrames(XrTime time) {
+    cached_quadviews_frames_.PruneThrough(time);
 }
 
 bool OpenXrLayer::IsTrackedViewSpace(XrSpace space) const {
@@ -9447,9 +9438,13 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
                                          uint32_t view_capacity_input,
                                          uint32_t* view_count_output,
                                          XrView* views,
-                                         bool* synthesized_quad_views) {
+                                         bool* synthesized_quad_views,
+                                         QuadViewsGazeDiagnostic* gaze_diagnostic) {
     if (synthesized_quad_views) {
         *synthesized_quad_views = false;
+    }
+    if (gaze_diagnostic) {
+        *gaze_diagnostic = {};
     }
 
     bool quadviews_emulation_active = false;
@@ -9618,6 +9613,13 @@ XrResult OpenXrLayer::LocateRuntimeViews(XrSession session,
             quadviews_last_focus_smoothing_wall_time_ = now;
             focus_yaw_radians = quadviews_smoothed_focus_yaw_radians_;
             focus_pitch_radians = quadviews_smoothed_focus_pitch_radians_;
+        }
+        if (gaze_diagnostic) {
+            gaze_diagnostic->valid = has_eye_focus && quadviews_raw_focus_valid_;
+            gaze_diagnostic->raw_yaw_radians = quadviews_raw_focus_yaw_radians_;
+            gaze_diagnostic->raw_pitch_radians = quadviews_raw_focus_pitch_radians_;
+            gaze_diagnostic->smoothed_yaw_radians = focus_yaw_radians;
+            gaze_diagnostic->smoothed_pitch_radians = focus_pitch_radians;
         }
     }
 

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -1689,6 +1689,12 @@ void OpenXrLayer::SetNextProcAddr(PFN_xrGetInstanceProcAddr next_get_instance_pr
 
 bool OpenXrLayer::PollInputBindingDown(const InputBinding& binding) {
     const InputBindingPollResult poll = PollInputBinding(binding);
+    if (poll.device_retry_deferred) {
+        // The first real failure already recorded the unavailable-device
+        // diagnostic. Keep deferred bindings entirely off Logger's mutex and
+        // string-formatting path until the per-device reconnect deadline.
+        return false;
+    }
     if (!poll.device_poll_attempted) {
         return poll.down;
     }
@@ -1717,6 +1723,9 @@ bool OpenXrLayer::PollInputBindingDown(const InputBinding& binding) {
         }
         if (poll.retry_attempted) {
             append_result(stream, "retryResult", poll.retry_result_code);
+        }
+        if (poll.device_retry_delay_ms > 0) {
+            stream << ", nextReconnectInMs=" << poll.device_retry_delay_ms;
         }
     };
 
@@ -1751,7 +1760,9 @@ bool OpenXrLayer::PollInputBindingDown(const InputBinding& binding) {
         const bool interval_elapsed = !state.last_log_time.has_value() ||
                                       now - *state.last_log_time >= kInputDeviceFailureLogInterval;
         state.failure_active = true;
-        ++state.failed_attempts;
+        if (!poll.device_retry_deferred) {
+            ++state.failed_attempts;
+        }
         if (changed || interval_elapsed) {
             std::ostringstream stream;
             stream << "Input device polling unavailable: ";
@@ -1760,7 +1771,7 @@ bool OpenXrLayer::PollInputBindingDown(const InputBinding& binding) {
             if (state.suppressed_attempts > 0) {
                 stream << ", suppressedRepeats=" << state.suppressed_attempts;
             }
-            stream << ". The binding will remain inactive while VectorXR retries.";
+            stream << ". The binding will remain inactive while VectorXR retries with reconnect backoff.";
             logger_.Info(stream.str());
             state.signature = signature;
             state.last_log_time = now;

--- a/layer/src/openxr_layer.cpp
+++ b/layer/src/openxr_layer.cpp
@@ -2293,7 +2293,8 @@ XrResult OpenXrLayer::EndSession(XrSession session) {
     }
 
     if (begin_pending_frame) {
-        const XrResult begin_result = next_begin_frame_(session, nullptr);
+        const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+        const XrResult begin_result = next_begin_frame_(session, &begin_info);
         if (XR_FAILED(begin_result)) {
             logger_.Info("Session end: unable to balance Turbo's pending xrBeginFrame, result=" +
                          std::to_string(static_cast<int>(begin_result)) + ".");
@@ -4548,6 +4549,10 @@ bool OpenXrLayer::ComposeQuadViewsD3D11(const XrCompositionLayerProjection* sour
 XrResult OpenXrLayer::WaitFrame(XrSession session,
                                 const XrFrameWaitInfo* frame_wait_info,
                                 XrFrameState* frame_state) {
+    if (!frame_state || (frame_wait_info && frame_wait_info->type != XR_TYPE_FRAME_WAIT_INFO) ||
+        frame_state->type != XR_TYPE_FRAME_STATE) {
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
     if (!turbo_frame_interception_required_.load(std::memory_order_acquire)) {
         if (!frame_pacing_debug_enabled_.load(std::memory_order_relaxed)) {
             return next_wait_frame_(session, frame_wait_info, frame_state);
@@ -4574,13 +4579,11 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
         }
         return result;
     }
-    if (!frame_state) {
-        return next_wait_frame_(session, frame_wait_info, frame_state);
-    }
-
     {
         std::unique_lock lock(turbo_mutex_);
-        const bool wait_pipelined = turbo_async_wait_.valid();
+        bool wait_pipelined = turbo_async_wait_.valid();
+        bool async_handoff = turbo_async_handoff_active_;
+        bool async_interception_cancelled = false;
         // Fabricate while a pipelined wait is outstanding (async pacing) or
         // the sequenced pipeline is established — in both cases the runtime
         // already owns this frame's pacing and this wait must never reach it.
@@ -4588,8 +4591,18 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
         // DCS calls xrWaitFrame concurrently with xrEndFrame, and any gap
         // here would let that wait reach the runtime alongside our own
         // (hardlock).
-        if (wait_pipelined || turbo_seq_state_ == TurboSequencedState::kActive) {
-            if (!wait_pipelined && !turbo_valve_open_) {
+        if (wait_pipelined || async_handoff || turbo_seq_state_ == TurboSequencedState::kActive) {
+            if (async_handoff) {
+                ++turbo_async_handoff_wait_intercepts_;
+                if (turbo_async_handoff_debug_log_budget_ > 0 && logger_.IsDebugEnabled()) {
+                    --turbo_async_handoff_debug_log_budget_;
+                    logger_.Debug("Turbo-diag: app xrWaitFrame intercepted by async handoff shield; "
+                                  "generation=" + std::to_string(turbo_async_wait_generation_) +
+                                  ", futurePublished=" + (wait_pipelined ? "1" : "0") +
+                                  ", alreadyPolled=" + (turbo_async_wait_polled_ ? "1" : "0") + ".");
+                }
+            }
+            if (!wait_pipelined && !async_handoff && !turbo_valve_open_) {
                 // Valve closed (turbo toggled off / suspended): re-couple the
                 // app to genuine runtime pacing without touching the pipeline
                 // topology — block until the next pre-wait posts a pacing
@@ -4621,65 +4634,101 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
                                   "ms, token=" + std::to_string(consumed_token ? 1 : 0));
                 }
             }
-            if (wait_pipelined) {
+            if (wait_pipelined || async_handoff) {
                 bool mark_wait_polled = true;
                 if (turbo_async_wait_polled_) {
                     // Second poll while pipelined: only one frame of
                     // pipelining is allowed, so now we must wait for the real
-                    // frame. Keep a shared snapshot: EndFrame may retire the
-                    // member while this app thread is blocked.
-                    const std::shared_future<void> pending_wait = turbo_async_wait_;
-                    const std::uint64_t pending_generation = turbo_async_wait_generation_;
-                    lock.unlock();
-                    pending_wait.wait();
-                    lock.lock();
-                    if (pending_generation != turbo_async_wait_generation_) {
-                        // EndFrame already retired this wait and may have
-                        // launched the following one. Do not mark that newer
-                        // wait as having been polled by this older call.
-                        mark_wait_polled = false;
+                    // frame. If EndFrame has pre-armed the handoff but not yet
+                    // published the worker future, first wait for publication
+                    // (or cancellation after a failed submit).
+                    if (!wait_pipelined && async_handoff) {
+                        ++turbo_async_handoff_second_poll_blocks_;
+                        if (turbo_async_handoff_debug_log_budget_ > 0 && logger_.IsDebugEnabled()) {
+                            --turbo_async_handoff_debug_log_budget_;
+                            logger_.Debug("Turbo-diag: second app xrWaitFrame waiting for async handoff "
+                                          "publication; generation=" +
+                                          std::to_string(turbo_async_wait_generation_) + ".");
+                        }
+                        turbo_async_handoff_cv_.wait(lock, [this] {
+                            return !turbo_async_handoff_active_ || turbo_async_wait_.valid();
+                        });
+                        wait_pipelined = turbo_async_wait_.valid();
+                        async_handoff = turbo_async_handoff_active_;
+                        if (!wait_pipelined && !async_handoff) {
+                            async_interception_cancelled = true;
+                            mark_wait_polled = false;
+                            if (turbo_async_handoff_debug_log_budget_ > 0 && logger_.IsDebugEnabled()) {
+                                --turbo_async_handoff_debug_log_budget_;
+                                logger_.Debug("Turbo-diag: async handoff cancelled while a second app "
+                                              "xrWaitFrame waited; returning to runtime pass-through.");
+                            }
+                        }
+                    }
+
+                    if (wait_pipelined) {
+                        // Keep a shared snapshot: EndFrame may retire the
+                        // member while this app thread is blocked.
+                        const std::shared_future<void> pending_wait = turbo_async_wait_;
+                        const std::uint64_t pending_generation = turbo_async_wait_generation_;
+                        lock.unlock();
+                        pending_wait.wait();
+                        lock.lock();
+                        if (pending_generation != turbo_async_wait_generation_) {
+                            // EndFrame already retired this wait and may have
+                            // launched the following one. Do not mark that newer
+                            // wait as having been polled by this older call.
+                            mark_wait_polled = false;
+                        }
                     }
                 }
-                if (mark_wait_polled) {
+                if (!async_interception_cancelled && mark_wait_polled) {
                     turbo_async_wait_polled_ = true;
                 }
             }
 
-            const auto now = std::chrono::steady_clock::now();
-            XrTime predicted = turbo_last_predicted_display_time_;
-            if (wait_pipelined && !turbo_async_wait_completed_ &&
-                turbo_last_wait_frame_wall_time_.has_value()) {
-                // Async wait still in flight: extrapolate by the wall-clock
-                // delta between the app's waits. (Sequenced pacing never needs
-                // this — its wait completed before EndFrame returned, so the
-                // recorded timing is already this frame's real timing.)
-                predicted += std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                 now - *turbo_last_wait_frame_wall_time_)
-                                 .count();
-            }
-            turbo_last_wait_frame_wall_time_ = now;
+            if (async_interception_cancelled) {
+                // The downstream submit failed and EndFrame cancelled the
+                // pre-publication shield. This call has not fabricated a frame,
+                // so it can safely resume normal runtime pacing below.
+            } else {
+                const auto now = std::chrono::steady_clock::now();
+                XrTime predicted = turbo_last_predicted_display_time_;
+                if ((wait_pipelined || async_handoff) && !turbo_async_wait_completed_ &&
+                    turbo_last_wait_frame_wall_time_.has_value()) {
+                    // Async wait still in flight: extrapolate by the wall-clock
+                    // delta between the app's waits. (Sequenced pacing never needs
+                    // this — its wait completed before EndFrame returned, so the
+                    // recorded timing is already this frame's real timing.)
+                    predicted += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                     now - *turbo_last_wait_frame_wall_time_)
+                                     .count();
+                }
+                turbo_last_wait_frame_wall_time_ = now;
 
-            // The spec requires predictedDisplayTime to increase monotonically.
-            // When the app polls twice for one pipelined frame (DCS menu does),
-            // step the second return forward by a display period rather than
-            // 1ns — two frames "predicted" for the same instant confuse the
-            // app's pose prediction and animation timing.
-            const XrTime min_step =
-                turbo_last_predicted_display_period_ > 0 ? turbo_last_predicted_display_period_ : 1;
-            frame_state->predictedDisplayTime =
-                std::max(predicted, turbo_max_returned_display_time_ + min_step);
-            frame_state->predictedDisplayPeriod = turbo_last_predicted_display_period_;
-            frame_state->shouldRender = turbo_last_should_render_ ? XR_TRUE : XR_FALSE;
-            turbo_max_returned_display_time_ = frame_state->predictedDisplayTime;
-            ++pacing_fabricated_waits_;
-            ++turbo_metrics_fabricated_pending_;
-            if (turbo_fabricated_wait_log_budget_ > 0 && logger_.IsDebugEnabled()) {
-                --turbo_fabricated_wait_log_budget_;
-                logger_.Debug("Turbo: fabricated xrWaitFrame return, predictedDisplayTime=" +
-                              std::to_string(frame_state->predictedDisplayTime) +
-                              ", asyncWaitCompleted=" + (turbo_async_wait_completed_ ? "1" : "0"));
+                // The spec requires predictedDisplayTime to increase monotonically.
+                // When the app polls twice for one pipelined frame (DCS menu does),
+                // step the second return forward by a display period rather than
+                // 1ns — two frames "predicted" for the same instant confuse the
+                // app's pose prediction and animation timing.
+                const XrTime min_step =
+                    turbo_last_predicted_display_period_ > 0 ? turbo_last_predicted_display_period_ : 1;
+                frame_state->predictedDisplayTime =
+                    std::max(predicted, turbo_max_returned_display_time_ + min_step);
+                frame_state->predictedDisplayPeriod = turbo_last_predicted_display_period_;
+                frame_state->shouldRender = turbo_last_should_render_ ? XR_TRUE : XR_FALSE;
+                turbo_max_returned_display_time_ = frame_state->predictedDisplayTime;
+                ++pacing_fabricated_waits_;
+                ++turbo_metrics_fabricated_pending_;
+                if (turbo_fabricated_wait_log_budget_ > 0 && logger_.IsDebugEnabled()) {
+                    --turbo_fabricated_wait_log_budget_;
+                    logger_.Debug("Turbo: fabricated xrWaitFrame return, predictedDisplayTime=" +
+                                  std::to_string(frame_state->predictedDisplayTime) +
+                                  ", asyncWaitCompleted=" + (turbo_async_wait_completed_ ? "1" : "0") +
+                                  ", asyncHandoff=" + (async_handoff ? "1" : "0"));
+                }
+                return XR_SUCCESS;
             }
-            return XR_SUCCESS;
         }
     }
 
@@ -4748,6 +4797,9 @@ XrResult OpenXrLayer::WaitFrame(XrSession session,
 }
 
 XrResult OpenXrLayer::BeginFrame(XrSession session, const XrFrameBeginInfo* frame_begin_info) {
+    if (frame_begin_info && frame_begin_info->type != XR_TYPE_FRAME_BEGIN_INFO) {
+        return XR_ERROR_VALIDATION_FAILURE;
+    }
     {
         std::scoped_lock lock(mutex_);
         if (session == active_session_) {
@@ -4782,10 +4834,20 @@ XrResult OpenXrLayer::BeginFrame(XrSession session, const XrFrameBeginInfo* fram
                 --turbo_seq_debug_log_budget_;
                 logger_.Debug("Turbo-diag: owed xrBeginFrame passing through to the runtime.");
             }
-        } else if (turbo_async_wait_.valid() || turbo_seq_state_ == TurboSequencedState::kActive) {
+        } else if (turbo_async_wait_.valid() || turbo_async_handoff_active_ ||
+                   turbo_seq_state_ == TurboSequencedState::kActive) {
             // Async pacing: deferred into ForwardEndFrame once the async wait
             // resolves. Sequenced pacing: the frame was pre-begun inside the
             // previous EndFrame (or will be compensated there).
+            if (turbo_async_handoff_active_) {
+                ++turbo_async_handoff_begin_intercepts_;
+                if (turbo_async_handoff_debug_log_budget_ > 0 && logger_.IsDebugEnabled()) {
+                    --turbo_async_handoff_debug_log_budget_;
+                    logger_.Debug("Turbo-diag: app xrBeginFrame intercepted by async handoff shield; "
+                                  "generation=" + std::to_string(turbo_async_wait_generation_) +
+                                  ", futurePublished=" + (turbo_async_wait_.valid() ? "1" : "0") + ".");
+                }
+            }
             return XR_SUCCESS;
         } else if (turbo_seq_state_ == TurboSequencedState::kEngaging &&
                    turbo_seq_debug_log_budget_ > 0 && logger_.IsDebugEnabled()) {
@@ -4967,7 +5029,7 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
     bool pipeline_established = false;
     {
         std::scoped_lock lock(turbo_mutex_);
-        pipeline_established = turbo_async_wait_.valid() ||
+        pipeline_established = turbo_async_wait_.valid() || turbo_async_handoff_active_ ||
                                turbo_seq_state_ == TurboSequencedState::kActive ||
                                turbo_seq_state_ == TurboSequencedState::kEngaging;
     }
@@ -5038,6 +5100,14 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
         seq_state = turbo_seq_state_;
         begin_owed = turbo_begin_owed_;
         valve_open = turbo_valve_open_;
+        if (!has_pending_wait && turbo_engaged && turbo_pacing_mode_ == TurboPacingMode::kAsync &&
+            seq_state == TurboSequencedState::kInactive) {
+            // Pre-arm before the runtime submit. DCS may issue its next app
+            // wait concurrently with this EndFrame; it must see interception
+            // even though the worker's real wait cannot start until EndFrame
+            // has returned downstream.
+            ArmTurboAsyncHandoffLocked("pre-submit async establishment");
+        }
         // From here until the runtime xrEndFrame returns, an owed
         // establishment begin arriving on another thread is deferred rather
         // than forwarded (Begin(N+1) must never reach the runtime before
@@ -5048,6 +5118,7 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
         std::scoped_lock lock(turbo_mutex_);
         turbo_end_frame_in_flight_ = false;
         turbo_begin_deferred_ = false;
+        CancelTurboAsyncHandoffLocked("frame forwarding aborted before submit");
     };
     if (TurboSequencedDebugTick()) {
         logger_.Debug("Turbo-diag: pre-submit snapshot: engaged=" + std::to_string(turbo_engaged ? 1 : 0) +
@@ -5088,6 +5159,13 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             if (ready && pending_async_generation == turbo_async_wait_generation_) {
                 async_wait_result = turbo_async_wait_result_;
                 turbo_async_wait_ = {};
+                if (turbo_engaged && turbo_pacing_mode_ == TurboPacingMode::kAsync &&
+                    turbo_seq_state_ == TurboSequencedState::kInactive) {
+                    // Retire and arm atomically under turbo_mutex_: an app
+                    // WaitFrame can observe the old future or the shield, but
+                    // never a pass-through gap between them.
+                    ArmTurboAsyncHandoffLocked("completed async wait retired before submit");
+                }
             }
         }
         if (ready && XR_FAILED(async_wait_result)) {
@@ -5111,7 +5189,8 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
         if (!frame_begun) {
             // Deferred xrBeginFrame for the pipelined frame. Errors pass
             // through (e.g. the session state machine advanced under us).
-            const XrResult begin_result = next_begin_frame_(session, nullptr);
+            const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+            const XrResult begin_result = next_begin_frame_(session, &begin_info);
             if (XR_FAILED(begin_result)) {
                 logger_.Error("Turbo: deferred xrBeginFrame failed with " +
                               std::to_string(static_cast<int>(begin_result)));
@@ -5138,11 +5217,12 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             logger_.Debug("Turbo-diag: compensation xrWaitFrame starting (frame thread).");
         }
         XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+        const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
         const auto comp_start = std::chrono::steady_clock::now();
         XrResult comp_result = XR_SUCCESS;
         {
             std::scoped_lock wait_lock(turbo_runtime_wait_mutex_);
-            comp_result = next_wait_frame_(session, nullptr, &frame_state);
+            comp_result = next_wait_frame_(session, &wait_info, &frame_state);
         }
         const double comp_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - comp_start)
@@ -5160,7 +5240,8 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                 turbo_last_should_render_ = frame_state.shouldRender == XR_TRUE;
                 NoteTurboShouldRenderLocked(turbo_last_should_render_);
             }
-            const XrResult begin_result = next_begin_frame_(session, nullptr);
+            const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+            const XrResult begin_result = next_begin_frame_(session, &begin_info);
             if (XR_FAILED(begin_result)) {
                 logger_.Error("Turbo: compensation xrBeginFrame failed with " +
                               std::to_string(static_cast<int>(begin_result)));
@@ -5265,11 +5346,12 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                     logger_.Debug("Turbo: sequenced wait+begin starting (frame thread).");
                 }
                 XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+                const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
                 const auto wait_start = std::chrono::steady_clock::now();
                 XrResult wait_result = XR_SUCCESS;
                 {
                     std::scoped_lock wait_lock(turbo_runtime_wait_mutex_);
-                    wait_result = next_wait_frame_(session, nullptr, &frame_state);
+                    wait_result = next_wait_frame_(session, &wait_info, &frame_state);
                 }
                 const double wait_ms =
                     std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
@@ -5298,7 +5380,8 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                         turbo_pacing_tokens_ = 1;
                         turbo_valve_cv_.notify_all();
                     }
-                    const XrResult begin_result = next_begin_frame_(session, nullptr);
+                    const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+                    const XrResult begin_result = next_begin_frame_(session, &begin_info);
                     if (XR_SUCCEEDED(begin_result)) {
                         std::scoped_lock lock(turbo_mutex_);
                         turbo_frame_begun_ = true;
@@ -5335,19 +5418,24 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                 if (!turbo_pipelining_logged_) {
                     logger_.Info("Turbo: frame pipelining engaged (async pacing); the app's xrWaitFrame "
                                  "is now decoupled from runtime pacing.");
+                    logger_.Info("Turbo: async frame handoffs are gap-shielded for applications that overlap "
+                                 "xrWaitFrame with xrEndFrame.");
                     logger_.Info("Turbo compatibility notice: frame pipelining can prevent runtime "
                                  "reprojection or frame synthesis (including SteamVR Motion Smoothing). "
                                  "Disable Turbo first if presentation becomes unstable.");
                     turbo_pipelining_logged_ = true;
                     turbo_fabricated_wait_log_budget_ = 5;
                 }
-                turbo_async_wait_polled_ = false;
-                turbo_async_wait_completed_ = false;
+                if (!turbo_async_handoff_active_) {
+                    // Defensive recovery only: the normal path arms before
+                    // xrEndFrame, where an overlapping app wait can see it.
+                    ArmTurboAsyncHandoffLocked("post-submit async recovery");
+                }
                 turbo_async_wait_result_ = XR_SUCCESS;
-                ++turbo_async_wait_generation_;
                 EnsureTurboAsyncWorkerLocked();
                 turbo_async_job_completion_ = std::make_shared<std::promise<void>>();
                 turbo_async_wait_ = turbo_async_job_completion_->get_future().share();
+                PublishTurboAsyncHandoffLocked();
                 turbo_async_job_session_ = session;
                 turbo_async_job_pending_ = true;
                 turbo_async_worker_cv_.notify_one();
@@ -5366,6 +5454,7 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
             // not-yet-established handshake is dropped, and the async
             // drain-out is logged.
             std::scoped_lock lock(turbo_mutex_);
+            CancelTurboAsyncHandoffLocked("turbo disengaged before async publication");
             if (turbo_seq_state_ == TurboSequencedState::kEngaging) {
                 // Nothing was pipelined yet; drop the handshake request.
                 turbo_seq_state_ = TurboSequencedState::kInactive;
@@ -5380,6 +5469,9 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
                 turbo_pipelining_logged_ = false;
             }
         }
+    } else {
+        std::scoped_lock lock(turbo_mutex_);
+        CancelTurboAsyncHandoffLocked("runtime xrEndFrame failed");
     }
 
     // The submit is down; release the owed-begin deferral window. If the
@@ -5400,7 +5492,8 @@ XrResult OpenXrLayer::ForwardEndFrame(XrSession session,
         if (TurboSequencedDebugTick()) {
             logger_.Debug("Turbo-diag: issuing deferred establishment xrBeginFrame (frame thread).");
         }
-        const XrResult begin_result = next_begin_frame_(session, nullptr);
+        const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+        const XrResult begin_result = next_begin_frame_(session, &begin_info);
         if (XR_SUCCEEDED(begin_result)) {
             std::scoped_lock lock(turbo_mutex_);
             turbo_frame_begun_ = true;
@@ -5729,6 +5822,12 @@ void OpenXrLayer::RecordFramePacing(std::chrono::steady_clock::time_point frame_
         double submit_delta_min_periods = 0.0;
         double submit_delta_max_periods = 0.0;
         uint32_t submit_delta_samples = 0;
+        std::uint64_t async_handoff_armed = 0;
+        std::uint64_t async_handoff_waits = 0;
+        std::uint64_t async_handoff_begins = 0;
+        std::uint64_t async_handoff_second_poll_blocks = 0;
+        std::uint64_t async_handoff_cancellations = 0;
+        bool async_handoff_active = false;
         {
             std::scoped_lock lock(turbo_mutex_);
             wait_sum_ms = pacing_wait_sum_ms_;
@@ -5739,6 +5838,12 @@ void OpenXrLayer::RecordFramePacing(std::chrono::steady_clock::time_point frame_
             submit_delta_min_periods = pacing_submit_delta_min_periods_;
             submit_delta_max_periods = pacing_submit_delta_max_periods_;
             submit_delta_samples = pacing_submit_delta_samples_;
+            async_handoff_armed = turbo_async_handoff_armed_total_;
+            async_handoff_waits = turbo_async_handoff_wait_intercepts_;
+            async_handoff_begins = turbo_async_handoff_begin_intercepts_;
+            async_handoff_second_poll_blocks = turbo_async_handoff_second_poll_blocks_;
+            async_handoff_cancellations = turbo_async_handoff_cancellations_;
+            async_handoff_active = turbo_async_handoff_active_;
             pacing_submit_delta_sum_periods_ = 0.0;
             pacing_submit_delta_min_periods_ = 0.0;
             pacing_submit_delta_max_periods_ = 0.0;
@@ -5772,6 +5877,12 @@ void OpenXrLayer::RecordFramePacing(std::chrono::steady_clock::time_point frame_
             stream << "n/a";
         }
         stream << ", fabricatedWaits=" << fabricated_waits;
+        if (turbo_pacing_mode_ == TurboPacingMode::kAsync || async_handoff_armed > 0) {
+            stream << ", asyncHandoff active/armed/waits/begins/secondPollBlocks/cancels="
+                   << (async_handoff_active ? 1 : 0) << "/" << async_handoff_armed << "/"
+                   << async_handoff_waits << "/" << async_handoff_begins << "/"
+                   << async_handoff_second_poll_blocks << "/" << async_handoff_cancellations;
+        }
         if (submit_delta_samples > 0) {
             stream << ", submittedDisplayTimeVsLatestWait avg/min/max="
                    << FormatDiagnosticDouble(submit_delta_sum_periods / submit_delta_samples) << "/"
@@ -6039,6 +6150,62 @@ void OpenXrLayer::ResetTurboMetricsState() {
     turbo_metrics_fabricated_pending_ = 0;
 }
 
+void OpenXrLayer::ArmTurboAsyncHandoffLocked(const char* reason) {
+    if (turbo_async_handoff_active_) {
+        return;
+    }
+    turbo_async_handoff_active_ = true;
+    turbo_async_wait_polled_ = false;
+    turbo_async_wait_completed_ = false;
+    ++turbo_async_wait_generation_;
+    ++turbo_async_handoff_armed_total_;
+    if (turbo_async_handoff_armed_total_ == 1) {
+        // Capture establishment and the first several steady-state handoffs,
+        // then rely on the five-second aggregate so debug logging cannot turn
+        // into a per-frame pacing cost.
+        turbo_async_handoff_debug_log_budget_ = 64;
+    }
+    if (logger_.IsDebugEnabled() && turbo_async_handoff_debug_log_budget_ > 0) {
+        --turbo_async_handoff_debug_log_budget_;
+        logger_.Debug("Turbo-diag: async handoff shield armed; reason=" +
+                      std::string(reason ? reason : "unknown") +
+                      ", generation=" + std::to_string(turbo_async_wait_generation_) +
+                      ", armedTotal=" + std::to_string(turbo_async_handoff_armed_total_) + ".");
+    }
+}
+
+void OpenXrLayer::PublishTurboAsyncHandoffLocked() {
+    if (!turbo_async_handoff_active_) {
+        return;
+    }
+    if (!turbo_async_wait_.valid()) {
+        CancelTurboAsyncHandoffLocked("publication missing worker future");
+        return;
+    }
+    turbo_async_handoff_active_ = false;
+    turbo_async_handoff_cv_.notify_all();
+    if (logger_.IsDebugEnabled() && turbo_async_handoff_debug_log_budget_ > 0) {
+        --turbo_async_handoff_debug_log_budget_;
+        logger_.Debug("Turbo-diag: async handoff published runtime wait; generation=" +
+                      std::to_string(turbo_async_wait_generation_) +
+                      ", interceptedWaits=" + std::to_string(turbo_async_handoff_wait_intercepts_) +
+                      ", interceptedBegins=" + std::to_string(turbo_async_handoff_begin_intercepts_) + ".");
+    }
+}
+
+void OpenXrLayer::CancelTurboAsyncHandoffLocked(const char* reason) {
+    if (!turbo_async_handoff_active_) {
+        return;
+    }
+    turbo_async_handoff_active_ = false;
+    ++turbo_async_handoff_cancellations_;
+    turbo_async_handoff_cv_.notify_all();
+    logger_.Info("Turbo: async handoff shield cancelled; reason=" +
+                 std::string(reason ? reason : "unknown") +
+                 ", generation=" + std::to_string(turbo_async_wait_generation_) +
+                 ", cancellations=" + std::to_string(turbo_async_handoff_cancellations_) + ".");
+}
+
 void OpenXrLayer::EnsureTurboAsyncWorkerLocked() {
     if (turbo_async_worker_.joinable()) {
         return;
@@ -6065,10 +6232,11 @@ void OpenXrLayer::TurboAsyncWorkerLoop() {
         }
 
         XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+        const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
         XrResult wait_result = XR_SUCCESS;
         {
             std::scoped_lock wait_lock(turbo_runtime_wait_mutex_);
-            wait_result = next_wait_frame_(session, nullptr, &frame_state);
+            wait_result = next_wait_frame_(session, &wait_info, &frame_state);
         }
         {
             std::scoped_lock state_lock(turbo_mutex_);
@@ -6160,6 +6328,14 @@ void OpenXrLayer::ResetTurboFrameState() {
     pacing_submit_delta_min_periods_ = 0.0;
     pacing_submit_delta_max_periods_ = 0.0;
     pacing_submit_delta_samples_ = 0;
+    turbo_async_handoff_active_ = false;
+    turbo_async_handoff_armed_total_ = 0;
+    turbo_async_handoff_wait_intercepts_ = 0;
+    turbo_async_handoff_begin_intercepts_ = 0;
+    turbo_async_handoff_second_poll_blocks_ = 0;
+    turbo_async_handoff_cancellations_ = 0;
+    turbo_async_handoff_debug_log_budget_ = 0;
+    turbo_async_handoff_cv_.notify_all();
     turbo_async_wait_ = {};
     ++turbo_async_wait_generation_;
     turbo_async_wait_polled_ = false;
@@ -6197,7 +6373,7 @@ void OpenXrLayer::ResetTurboFrameState() {
 }
 
 XrResult OpenXrLayer::EndFrame(XrSession session, const XrFrameEndInfo* frame_end_info) {
-    if (!frame_end_info) {
+    if (!frame_end_info || frame_end_info->type != XR_TYPE_FRAME_END_INFO) {
         return XR_ERROR_VALIDATION_FAILURE;
     }
 

--- a/layer/tests/config_tests.cpp
+++ b/layer/tests/config_tests.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
@@ -2330,9 +2331,10 @@ void TestPivotLocateViewsRouting() {
     };
 
     record_locate_result(false, 100, 42);
+    record_locate_result(false, 100, 99);
     record_locate_result(true, 100, 0);
     expect_delta(100, 42,
-                 "A later VIEW-relative query must not overwrite the world-space frame delta");
+                 "Repeated same-time queries must reuse the first logical Pivot frame delta");
 
     pose_deltas.clear();
     record_locate_result(true, 200, 0);
@@ -2388,6 +2390,116 @@ void TestPivotLocateViewsRouting() {
                depthxr::PivotPoseDeltaSelection::Matched &&
                !held_pose_delta.has_value() && consecutive_misses == 0,
            "Inactive Pivot routing must disarm the held correction");
+}
+
+void TestPivotPoseDeltaSpaceReexpression() {
+    using Matrix = std::array<double, 9>;
+    using Vector = std::array<double, 3>;
+    const auto multiply = [](const Matrix& lhs, const Matrix& rhs) {
+        Matrix result{};
+        for (size_t row = 0; row < 3; ++row) {
+            for (size_t column = 0; column < 3; ++column) {
+                for (size_t inner = 0; inner < 3; ++inner) {
+                    result[row * 3 + column] +=
+                        lhs[row * 3 + inner] * rhs[inner * 3 + column];
+                }
+            }
+        }
+        return result;
+    };
+    const auto inverse_rotation = [](const Matrix& matrix) {
+        return Matrix{
+            matrix[0], matrix[3], matrix[6],
+            matrix[1], matrix[4], matrix[7],
+            matrix[2], matrix[5], matrix[8],
+        };
+    };
+    const auto transform = [](const Matrix& matrix, const Vector& vector) {
+        return Vector{
+            matrix[0] * vector[0] + matrix[1] * vector[1] + matrix[2] * vector[2],
+            matrix[3] * vector[0] + matrix[4] * vector[1] + matrix[5] * vector[2],
+            matrix[6] * vector[0] + matrix[7] * vector[1] + matrix[8] * vector[2],
+        };
+    };
+    const auto nearly_equal = [](const Vector& lhs, const Vector& rhs) {
+        for (size_t index = 0; index < lhs.size(); ++index) {
+            if (std::abs(lhs[index] - rhs[index]) > 0.000001) {
+                return false;
+            }
+        }
+        return true;
+    };
+    const auto yaw = [](double radians) {
+        const double cosine = std::cos(radians);
+        const double sine = std::sin(radians);
+        return Matrix{
+            cosine, 0.0, sine,
+            0.0, 1.0, 0.0,
+            -sine, 0.0, cosine,
+        };
+    };
+    const auto pitch = [](double radians) {
+        const double cosine = std::cos(radians);
+        const double sine = std::sin(radians);
+        return Matrix{
+            1.0, 0.0, 0.0,
+            0.0, cosine, -sine,
+            0.0, sine, cosine,
+        };
+    };
+
+    constexpr double kPi = 3.14159265358979323846;
+    const Matrix source_in_target = yaw(-112.0 * kPi / 180.0);
+    const Matrix source_pitch_delta = pitch(30.0 * kPi / 180.0);
+    const Matrix target_delta = depthxr::ReexpressPivotPoseDelta(
+        source_pitch_delta, source_in_target, multiply, inverse_rotation);
+    const Vector source_vector{0.2, 0.7, -0.4};
+
+    // Conjugation must make applying the delta before or after the coordinate
+    // change equivalent. A raw source-space pitch fails this property when the
+    // spaces differ by yaw (the IL-2 diagonal-roll signature).
+    const Vector expected = transform(
+        source_in_target, transform(source_pitch_delta, source_vector));
+    const Vector converted = transform(
+        target_delta, transform(source_in_target, source_vector));
+    const Vector unconverted = transform(
+        source_pitch_delta, transform(source_in_target, source_vector));
+    Expect(nearly_equal(converted, expected),
+           "A Pivot delta must be conjugated into the projection layer's space");
+    Expect(!nearly_equal(unconverted, expected),
+           "Applying an unconverted pitch across yawed spaces must expose the regression test");
+
+    // Repeat the group property with a homogeneous 2D rigid transform so the
+    // positional part of a Pivot/neck offset is covered as well as rotation.
+    const auto rigid_2d = [](double radians, double x, double y) {
+        const double cosine = std::cos(radians);
+        const double sine = std::sin(radians);
+        return Matrix{
+            cosine, -sine, x,
+            sine, cosine, y,
+            0.0, 0.0, 1.0,
+        };
+    };
+    const auto inverse_rigid_2d = [](const Matrix& matrix) {
+        const double inverse_x = -(matrix[0] * matrix[2] + matrix[3] * matrix[5]);
+        const double inverse_y = -(matrix[1] * matrix[2] + matrix[4] * matrix[5]);
+        return Matrix{
+            matrix[0], matrix[3], inverse_x,
+            matrix[1], matrix[4], inverse_y,
+            0.0, 0.0, 1.0,
+        };
+    };
+    const Matrix source_pose_in_target = rigid_2d(-1.2, 1.4, -0.6);
+    const Matrix source_rigid_delta = rigid_2d(0.4, 0.25, -0.1);
+    const Matrix target_rigid_delta = depthxr::ReexpressPivotPoseDelta(
+        source_rigid_delta, source_pose_in_target, multiply, inverse_rigid_2d);
+    const Vector source_point{0.3, -0.8, 1.0};
+    const Vector rigid_expected = transform(
+        source_pose_in_target, transform(source_rigid_delta, source_point));
+    const Vector rigid_converted = transform(
+        target_rigid_delta, transform(source_pose_in_target, source_point));
+    Expect(nearly_equal(rigid_converted, rigid_expected),
+           "A full rigid Pivot delta must preserve rotation and translation across spaces");
 }
 
 void TestNumpadActivationKeys() {
@@ -2553,6 +2665,7 @@ int main() {
     TestQuadViewsFrameCacheKeepsGazeWithLocatedFrame();
     TestQuadViewsCanvasDimensionsMatchCompositionDensity();
     TestPivotLocateViewsRouting();
+    TestPivotPoseDeltaSpaceReexpression();
     TestNumpadActivationKeys();
     TestDeviceInputPathsAndHatDirections();
 #ifdef _WIN32

--- a/layer/tests/config_tests.cpp
+++ b/layer/tests/config_tests.cpp
@@ -14,6 +14,7 @@
 #include "depthxr/pivot_routing.h"
 #include "depthxr/pivot_step.h"
 #include "depthxr/pivot_view.h"
+#include "depthxr/quadviews_frame_cache.h"
 #include "depthxr/quadviews_recovery.h"
 #include "depthxr/quadviews_sizing.h"
 #include "depthxr/runtime_pacing.h"
@@ -2266,6 +2267,45 @@ void TestQuadViewsRecoveryStabilizer() {
     Expect(stabilizer.Ready(start), "Other runtimes must retain immediate recovery");
 }
 
+void TestQuadViewsFrameCacheKeepsGazeWithLocatedFrame() {
+    struct Frame {
+        bool gaze_valid{false};
+        double raw_yaw{0.0};
+        double smoothed_yaw{0.0};
+    };
+
+    depthxr::QuadViewsFrameCache<Frame> cache;
+    cache.Store(1'000, Frame{true, 0.10, 0.08}, 180);
+    // A later locate must not replace the gaze diagnostics associated with an
+    // older frame that the application submits afterward.
+    cache.Store(2'000, Frame{false, 0.40, 0.30}, 180);
+
+    Frame selected;
+    std::int64_t matched_time = 0;
+    Expect(cache.FindNearest(1'000, 100, &selected, &matched_time),
+           "Exact Quadviews frame-cache lookup should succeed");
+    Expect(matched_time == 1'000 && selected.gaze_valid &&
+               std::abs(selected.raw_yaw - 0.10) < 0.0001 &&
+               std::abs(selected.smoothed_yaw - 0.08) < 0.0001,
+           "Quadviews frame cache must return the gaze snapshot stored with the submitted frame");
+
+    Expect(cache.FindNearest(1'040, 50, &selected, &matched_time) && matched_time == 1'000 &&
+               selected.gaze_valid,
+           "Nearest Quadviews frame lookup should preserve the matched frame's gaze validity");
+    Expect(!cache.FindNearest(1'500, 100, &selected, &matched_time) && matched_time == 1'000,
+           "Quadviews frame lookup should reject a nearest frame outside the match window");
+
+    cache.Store(3'000, Frame{true, 0.50, 0.45}, 2);
+    Expect(cache.Size() == 2,
+           "Quadviews frame cache should enforce its bounded retention count");
+    Expect(!cache.FindNearest(1'000, 0, &selected, &matched_time),
+           "Quadviews frame cache should discard the oldest frame when retention is exceeded");
+
+    cache.PruneThrough(2'000);
+    Expect(cache.Size() == 1 && cache.FindNearest(3'000, 0, &selected, &matched_time),
+           "Quadviews frame cache should prune submitted frames while keeping future frames");
+}
+
 void TestPivotLocateViewsRouting() {
     Expect(depthxr::ShouldDrivePivotFromLocateViews(true, false),
            "A world-space xrLocateViews query must drive Pivot frame state");
@@ -2510,6 +2550,7 @@ int main() {
     TestQuadViewsSessionActivationPolicy();
     TestQuadViewsRecoveryStabilizationPolicy();
     TestQuadViewsRecoveryStabilizer();
+    TestQuadViewsFrameCacheKeepsGazeWithLocatedFrame();
     TestQuadViewsCanvasDimensionsMatchCompositionDensity();
     TestPivotLocateViewsRouting();
     TestNumpadActivationKeys();

--- a/layer/tests/config_tests.cpp
+++ b/layer/tests/config_tests.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
@@ -2568,7 +2569,87 @@ void TestDeviceInputPathsAndHatDirections() {
     Expect(invalid_device.device_poll_attempted &&
                invalid_device.diagnostic_stage == depthxr::InputBindingPollStage::ParseInputPath,
            "Invalid device bindings must report their failing stage before touching DirectInput");
+
+    depthxr::InputBinding missing_device_binding;
+    missing_device_binding.type = depthxr::InputBindingType::Device;
+    missing_device_binding.device_guid = "{11111111-2222-3333-4444-555555555555}";
+    missing_device_binding.input_path = "button-1";
+    const depthxr::InputBindingPollResult first_missing_device =
+        depthxr::PollInputBinding(missing_device_binding);
+    const depthxr::InputBindingPollResult repeated_missing_device =
+        depthxr::PollInputBinding(missing_device_binding);
+    Expect(first_missing_device.device_poll_attempted &&
+               !first_missing_device.device_retry_deferred &&
+               first_missing_device.diagnostic_stage != depthxr::InputBindingPollStage::None &&
+               first_missing_device.device_retry_delay_ms >= 250,
+           "The first missing-device poll must record a real DirectInput failure and reconnect deadline");
+    Expect(repeated_missing_device.device_retry_deferred &&
+               repeated_missing_device.diagnostic_stage == first_missing_device.diagnostic_stage &&
+               repeated_missing_device.result_code == first_missing_device.result_code,
+           "A repeated missing-device binding must reuse the failure without touching DirectInput");
 #endif
+}
+
+void TestInputDeviceRetryBackoff() {
+    using Backoff = depthxr::InputDeviceRetryBackoff;
+    using namespace std::chrono_literals;
+
+    Backoff backoff(100ms, 400ms);
+    const std::wstring foxtrot = L"{foxtrot-guid}";
+    const std::wstring throttle = L"{throttle-guid}";
+    const Backoff::TimePoint start{};
+
+    Expect(backoff.ShouldAttempt(foxtrot, start),
+           "A device with no failure history must be polled immediately");
+    Expect(backoff.RecordFailure(foxtrot, start) == 100ms &&
+               backoff.ConsecutiveFailures(foxtrot) == 1,
+           "The first unavailable-device retry must use the initial delay");
+    Expect(!backoff.ShouldAttempt(foxtrot, start + 99ms) &&
+               backoff.RetryDelayRemaining(foxtrot, start + 40ms) == 60ms,
+           "Bindings for one unavailable device must share its retry window");
+    Expect(backoff.ShouldAttempt(foxtrot, start + 100ms),
+           "An unavailable device must become eligible at its reconnect deadline");
+    Expect(backoff.ShouldAttempt(throttle, start + 50ms),
+           "One unavailable device must not delay a different device");
+
+    Expect(backoff.RecordFailure(foxtrot, start + 100ms) == 200ms &&
+               backoff.RecordFailure(foxtrot, start + 300ms) == 400ms &&
+               backoff.RecordFailure(foxtrot, start + 700ms) == 400ms,
+           "Repeated reconnect failures must double to, but never exceed, the cap");
+    Expect(!backoff.ShouldAttempt(foxtrot, start + 1099ms) &&
+               backoff.ShouldAttempt(foxtrot, start + 1100ms),
+           "The capped retry window must remain deterministic");
+
+    backoff.RecordSuccess(foxtrot);
+    Expect(backoff.ShouldAttempt(foxtrot, start + 701ms) &&
+               backoff.ConsecutiveFailures(foxtrot) == 0 &&
+               backoff.RetryDelayRemaining(foxtrot, start + 701ms) == 0ms,
+           "A successful device read must clear reconnect backoff immediately");
+
+    Backoff clamped(0ms, 0ms);
+    Expect(clamped.RecordFailure(foxtrot, start) == 1ms,
+           "A misconfigured reconnect policy must retain a nonzero retry delay");
+
+    // Model ten Pivot bindings sharing one unplugged controller at the layer's
+    // 30ms polling interval. Before the negative cache this produced roughly
+    // 3,340 DirectInput setup attempts in ten seconds; the production policy
+    // should permit only the bounded reconnect probes.
+    Backoff production_policy;
+    std::size_t device_attempts = 0;
+    std::size_t deferred_bindings = 0;
+    for (int tick = 0; tick <= 333; ++tick) {
+        const Backoff::TimePoint now = start + tick * 30ms;
+        for (int binding = 0; binding < 10; ++binding) {
+            if (production_policy.ShouldAttempt(foxtrot, now)) {
+                ++device_attempts;
+                production_policy.RecordFailure(foxtrot, now);
+            } else {
+                ++deferred_bindings;
+            }
+        }
+    }
+    Expect(device_attempts <= 8 && deferred_bindings > 3'300,
+           "Reconnect backoff must collapse an unplugged multi-binding input storm");
 }
 
 void TestQuadViewsCanvasDimensionsMatchCompositionDensity() {
@@ -2668,6 +2749,7 @@ int main() {
     TestPivotPoseDeltaSpaceReexpression();
     TestNumpadActivationKeys();
     TestDeviceInputPathsAndHatDirections();
+    TestInputDeviceRetryBackoff();
 #ifdef _WIN32
     TestD3D11SharpenShaderRegression();
 #endif

--- a/layer/tests/turbo_frame_tests.cpp
+++ b/layer/tests/turbo_frame_tests.cpp
@@ -1,0 +1,645 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "depthxr/openxr_layer.h"
+
+using namespace std::chrono_literals;
+
+namespace depthxr {
+
+// Test-only access to the singleton's frame-pacing state. The production DLL
+// is compiled without DEPTHXR_TESTING, so this peer cannot affect its ABI or
+// hot paths.
+class TurboFrameTestPeer {
+  public:
+    enum class Source { kForced, kProbing, kFallback };
+
+    struct HandoffStats {
+        bool active{false};
+        bool wait_valid{false};
+        bool wait_completed{false};
+        std::uint64_t armed{0};
+        std::uint64_t wait_intercepts{0};
+        std::uint64_t begin_intercepts{0};
+        std::uint64_t second_poll_blocks{0};
+        std::uint64_t cancellations{0};
+    };
+
+    static OpenXrLayer& Layer() {
+        return OpenXrLayer::Instance();
+    }
+
+    static void Prepare(TurboPacingMode mode,
+                        PFN_xrWaitFrame wait_frame,
+                        PFN_xrBeginFrame begin_frame,
+                        PFN_xrEndFrame end_frame) {
+        OpenXrLayer& layer = Layer();
+        layer.StopTurboAsyncWorker();
+        layer.ResetTurboFrameState();
+
+        {
+            std::scoped_lock lock(layer.mutex_);
+            layer.resolved_settings_ = {};
+            layer.resolved_settings_.core.enabled = true;
+            layer.resolved_settings_.turbo.enabled = true;
+            layer.resolved_settings_.turbo.metrics_mode = TurboMetricsMode::kOff;
+            layer.resolved_settings_.turbo.pacing_mode =
+                mode == TurboPacingMode::kSequenced ? TurboPacingSetting::kSequenced
+                                                    : TurboPacingSetting::kAsync;
+            layer.current_exe_name_ = "turbo-frame-tests.exe";
+            layer.runtime_name_ = "Fake OpenXR Runtime";
+            layer.runtime_version_ = "test";
+            layer.active_session_ = XR_NULL_HANDLE;
+            layer.quadviews_session_active_ = false;
+            layer.varjo_compatible_quadviews_active_ = false;
+            layer.quad_views_extension_requested_ = false;
+            layer.varjo_foveated_rendering_extension_requested_ = false;
+            layer.turbo_toggle_enabled_ = true;
+            layer.turbo_binding_last_poll_time_ = std::chrono::steady_clock::now();
+            layer.turbo_binding_down_cached_ = false;
+            layer.turbo_pacing_mode_ = mode;
+            layer.turbo_pacing_source_ = OpenXrLayer::TurboPacingSource::kForced;
+            layer.turbo_pacing_resolved_ = true;
+            layer.turbo_pacing_verdict_pending_ = false;
+            layer.turbo_cadence_healthy_streak_ = 90;
+            layer.turbo_cadence_ready_ = true;
+            layer.session_begin_wall_time_ = std::chrono::steady_clock::now() - 10s;
+            layer.pacing_last_end_time_.reset();
+            layer.app_submitting_layers_.reset();
+            layer.next_wait_frame_ = wait_frame;
+            layer.next_begin_frame_ = begin_frame;
+            layer.next_end_frame_ = end_frame;
+            layer.frame_pacing_debug_enabled_.store(false, std::memory_order_relaxed);
+        }
+        {
+            std::scoped_lock lock(layer.turbo_mutex_);
+            layer.turbo_last_predicted_display_time_ = 10'000'000'000;
+            layer.turbo_last_predicted_display_period_ = 11'111'111;
+            layer.turbo_last_should_render_ = true;
+            layer.turbo_max_returned_display_time_ = 10'000'000'000;
+            layer.turbo_last_wait_frame_wall_time_ = std::chrono::steady_clock::now();
+            layer.turbo_frame_begun_ = true;
+            layer.turbo_valve_open_ = true;
+        }
+        layer.turbo_frame_interception_required_.store(true, std::memory_order_release);
+    }
+
+    static void Cleanup() {
+        OpenXrLayer& layer = Layer();
+        layer.StopTurboAsyncWorker();
+        layer.ResetTurboFrameState();
+    }
+
+    static XrResult ForwardEndFrame(XrSession session, const XrFrameEndInfo* frame_end_info) {
+        OpenXrLayer& layer = Layer();
+        std::unique_lock lock(layer.mutex_);
+        return layer.ForwardEndFrame(session, frame_end_info, lock);
+    }
+
+    static HandoffStats Handoff() {
+        OpenXrLayer& layer = Layer();
+        std::scoped_lock lock(layer.turbo_mutex_);
+        return {
+            layer.turbo_async_handoff_active_,
+            layer.turbo_async_wait_.valid(),
+            layer.turbo_async_wait_completed_,
+            layer.turbo_async_handoff_armed_total_,
+            layer.turbo_async_handoff_wait_intercepts_,
+            layer.turbo_async_handoff_begin_intercepts_,
+            layer.turbo_async_handoff_second_poll_blocks_,
+            layer.turbo_async_handoff_cancellations_,
+        };
+    }
+
+    static int SequencedState() {
+        OpenXrLayer& layer = Layer();
+        std::scoped_lock lock(layer.turbo_mutex_);
+        return static_cast<int>(layer.turbo_seq_state_);
+    }
+
+    static int EngagingState() {
+        return static_cast<int>(OpenXrLayer::TurboSequencedState::kEngaging);
+    }
+
+    static int ActiveState() {
+        return static_cast<int>(OpenXrLayer::TurboSequencedState::kActive);
+    }
+
+    static void SetPolicy(TurboPacingMode mode, Source source) {
+        OpenXrLayer& layer = Layer();
+        layer.turbo_pacing_mode_ = mode;
+        switch (source) {
+        case Source::kForced:
+            layer.turbo_pacing_source_ = OpenXrLayer::TurboPacingSource::kForced;
+            break;
+        case Source::kProbing:
+            layer.turbo_pacing_source_ = OpenXrLayer::TurboPacingSource::kProbing;
+            break;
+        case Source::kFallback:
+            layer.turbo_pacing_source_ = OpenXrLayer::TurboPacingSource::kFallback;
+            break;
+        }
+        layer.turbo_drain_timeout_count_ = 0;
+        layer.turbo_timeout_window_start_.reset();
+        layer.turbo_pacing_verdict_pending_ = false;
+        layer.turbo_auto_suspended_.store(false, std::memory_order_relaxed);
+    }
+
+    static TurboPacingMode PacingMode() {
+        return Layer().turbo_pacing_mode_;
+    }
+
+    static bool HandleTimeout(std::chrono::steady_clock::time_point now) {
+        return Layer().HandleTurboDrainTimeout(now);
+    }
+
+    static bool AutoSuspended() {
+        return Layer().turbo_auto_suspended_.load(std::memory_order_relaxed);
+    }
+};
+
+} // namespace depthxr
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(1);
+    }
+}
+
+enum class RuntimeCall { kWait, kBegin, kEnd };
+
+class FakeRuntime {
+  public:
+    FakeRuntime() {
+        Expect(active_ == nullptr, "Only one fake runtime may be active at a time");
+        active_ = this;
+    }
+
+    ~FakeRuntime() {
+        ReleaseAll();
+        active_ = nullptr;
+    }
+
+    FakeRuntime(const FakeRuntime&) = delete;
+    FakeRuntime& operator=(const FakeRuntime&) = delete;
+
+    static XrResult XRAPI_CALL WaitFrame(XrSession,
+                                         const XrFrameWaitInfo* frame_wait_info,
+                                         XrFrameState* frame_state) {
+        FakeRuntime& runtime = Active();
+        std::unique_lock lock(runtime.mutex_);
+        runtime.valid_structs_ = runtime.valid_structs_ && frame_wait_info && frame_state &&
+                                 frame_wait_info->type == XR_TYPE_FRAME_WAIT_INFO &&
+                                 frame_state->type == XR_TYPE_FRAME_STATE;
+        runtime.calls_.push_back(RuntimeCall::kWait);
+        ++runtime.wait_entered_;
+        ++runtime.active_waits_;
+        runtime.max_active_waits_ = std::max(runtime.max_active_waits_, runtime.active_waits_);
+        runtime.cv_.notify_all();
+        runtime.cv_.wait(lock, [&runtime] { return runtime.wait_released_; });
+        const XrResult result = runtime.wait_result_;
+        if (XR_SUCCEEDED(result) && frame_state) {
+            runtime.next_display_time_ += runtime.display_period_;
+            frame_state->predictedDisplayTime = runtime.next_display_time_;
+            frame_state->predictedDisplayPeriod = runtime.display_period_;
+            frame_state->shouldRender = XR_TRUE;
+        }
+        --runtime.active_waits_;
+        ++runtime.wait_exited_;
+        runtime.cv_.notify_all();
+        return result;
+    }
+
+    static XrResult XRAPI_CALL BeginFrame(XrSession, const XrFrameBeginInfo* frame_begin_info) {
+        FakeRuntime& runtime = Active();
+        std::scoped_lock lock(runtime.mutex_);
+        runtime.valid_structs_ = runtime.valid_structs_ && frame_begin_info &&
+                                 frame_begin_info->type == XR_TYPE_FRAME_BEGIN_INFO;
+        runtime.calls_.push_back(RuntimeCall::kBegin);
+        ++runtime.begin_calls_;
+        runtime.cv_.notify_all();
+        return runtime.begin_result_;
+    }
+
+    static XrResult XRAPI_CALL EndFrame(XrSession, const XrFrameEndInfo* frame_end_info) {
+        FakeRuntime& runtime = Active();
+        std::unique_lock lock(runtime.mutex_);
+        runtime.valid_structs_ = runtime.valid_structs_ && frame_end_info &&
+                                 frame_end_info->type == XR_TYPE_FRAME_END_INFO;
+        runtime.calls_.push_back(RuntimeCall::kEnd);
+        ++runtime.end_entered_;
+        if (runtime.release_wait_on_next_end_) {
+            runtime.release_wait_on_next_end_ = false;
+            runtime.wait_released_ = true;
+        }
+        runtime.cv_.notify_all();
+        runtime.cv_.wait(lock, [&runtime] { return runtime.end_released_; });
+        ++runtime.end_exited_;
+        runtime.cv_.notify_all();
+        return runtime.end_result_;
+    }
+
+    void BlockEnd() {
+        std::scoped_lock lock(mutex_);
+        end_released_ = false;
+    }
+
+    void ReleaseEnd() {
+        std::scoped_lock lock(mutex_);
+        end_released_ = true;
+        cv_.notify_all();
+    }
+
+    void BlockWait() {
+        std::scoped_lock lock(mutex_);
+        wait_released_ = false;
+    }
+
+    void ReleaseWait() {
+        std::scoped_lock lock(mutex_);
+        wait_released_ = true;
+        cv_.notify_all();
+    }
+
+    void ReleaseWaitOnNextEnd() {
+        std::scoped_lock lock(mutex_);
+        release_wait_on_next_end_ = true;
+    }
+
+    void ReleaseAll() {
+        std::scoped_lock lock(mutex_);
+        end_released_ = true;
+        wait_released_ = true;
+        cv_.notify_all();
+    }
+
+    void SetEndResult(XrResult result) {
+        std::scoped_lock lock(mutex_);
+        end_result_ = result;
+    }
+
+    bool WaitForEndEntered(int count, std::chrono::milliseconds timeout = 2s) {
+        std::unique_lock lock(mutex_);
+        return cv_.wait_for(lock, timeout, [this, count] { return end_entered_ >= count; });
+    }
+
+    bool WaitForWaitEntered(int count, std::chrono::milliseconds timeout = 2s) {
+        std::unique_lock lock(mutex_);
+        return cv_.wait_for(lock, timeout, [this, count] { return wait_entered_ >= count; });
+    }
+
+    bool WaitForWaitExited(int count, std::chrono::milliseconds timeout = 2s) {
+        std::unique_lock lock(mutex_);
+        return cv_.wait_for(lock, timeout, [this, count] { return wait_exited_ >= count; });
+    }
+
+    int WaitCalls() const {
+        std::scoped_lock lock(mutex_);
+        return wait_entered_;
+    }
+
+    int BeginCalls() const {
+        std::scoped_lock lock(mutex_);
+        return begin_calls_;
+    }
+
+    int EndCalls() const {
+        std::scoped_lock lock(mutex_);
+        return end_entered_;
+    }
+
+    int MaxConcurrentWaits() const {
+        std::scoped_lock lock(mutex_);
+        return max_active_waits_;
+    }
+
+    bool ValidStructs() const {
+        std::scoped_lock lock(mutex_);
+        return valid_structs_;
+    }
+
+    std::vector<RuntimeCall> Calls() const {
+        std::scoped_lock lock(mutex_);
+        return calls_;
+    }
+
+  private:
+    static FakeRuntime& Active() {
+        Expect(active_ != nullptr, "Fake runtime callback invoked without an active runtime");
+        return *active_;
+    }
+
+    inline static FakeRuntime* active_{nullptr};
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<RuntimeCall> calls_;
+    bool end_released_{true};
+    bool wait_released_{true};
+    bool release_wait_on_next_end_{false};
+    bool valid_structs_{true};
+    int wait_entered_{0};
+    int wait_exited_{0};
+    int begin_calls_{0};
+    int end_entered_{0};
+    int end_exited_{0};
+    int active_waits_{0};
+    int max_active_waits_{0};
+    XrResult wait_result_{XR_SUCCESS};
+    XrResult begin_result_{XR_SUCCESS};
+    XrResult end_result_{XR_SUCCESS};
+    XrTime next_display_time_{20'000'000'000};
+    XrDuration display_period_{11'111'111};
+};
+
+class TurboHarness {
+  public:
+    TurboHarness(FakeRuntime& runtime, depthxr::TurboPacingMode mode) : runtime_(runtime) {
+        depthxr::TurboFrameTestPeer::Prepare(mode,
+                                             &FakeRuntime::WaitFrame,
+                                             &FakeRuntime::BeginFrame,
+                                             &FakeRuntime::EndFrame);
+    }
+
+    ~TurboHarness() {
+        runtime_.ReleaseAll();
+        depthxr::TurboFrameTestPeer::Cleanup();
+    }
+
+  private:
+    FakeRuntime& runtime_;
+};
+
+XrSession TestSession() {
+    return reinterpret_cast<XrSession>(static_cast<std::uintptr_t>(0x1234));
+}
+
+XrFrameEndInfo FrameEndInfo() {
+    XrFrameEndInfo info{XR_TYPE_FRAME_END_INFO};
+    info.displayTime = 20'000'000'000;
+    info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    return info;
+}
+
+XrResult AppWait(XrFrameState* state) {
+    const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
+    return depthxr::TurboFrameTestPeer::Layer().WaitFrame(TestSession(), &wait_info, state);
+}
+
+XrResult AppBegin() {
+    const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+    return depthxr::TurboFrameTestPeer::Layer().BeginFrame(TestSession(), &begin_info);
+}
+
+bool WaitForSecondPollBlock() {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (depthxr::TurboFrameTestPeer::Handoff().second_poll_blocks > 0) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+void TestAsyncHandoffCoversEndFrameWindow() {
+    FakeRuntime runtime;
+    runtime.BlockEnd();
+    TurboHarness harness(runtime, depthxr::TurboPacingMode::kAsync);
+    const XrFrameEndInfo end_info = FrameEndInfo();
+
+    auto end_result = std::async(std::launch::async, [&] {
+        return depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info);
+    });
+    Expect(runtime.WaitForEndEntered(1), "Async establishment never entered runtime xrEndFrame");
+    Expect(depthxr::TurboFrameTestPeer::Handoff().active,
+           "Async handoff was not armed before runtime xrEndFrame");
+
+    XrFrameState state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&state) == XR_SUCCESS, "Handoff-shielded app xrWaitFrame failed");
+    Expect(AppBegin() == XR_SUCCESS, "Handoff-shielded app xrBeginFrame failed");
+    Expect(runtime.WaitCalls() == 0 && runtime.BeginCalls() == 0,
+           "An app frame call slipped through the pre-publication handoff shield");
+    Expect(state.predictedDisplayTime > 10'000'000'000 &&
+               state.predictedDisplayPeriod == 11'111'111,
+           "Fabricated async frame timing was not monotonic and period-correct");
+
+    runtime.ReleaseEnd();
+    Expect(end_result.wait_for(2s) == std::future_status::ready && end_result.get() == XR_SUCCESS,
+           "Async establishment xrEndFrame did not finish successfully");
+    Expect(runtime.WaitForWaitExited(1), "Async worker did not complete its runtime xrWaitFrame");
+
+    const auto handoff = depthxr::TurboFrameTestPeer::Handoff();
+    Expect(runtime.EndCalls() == 1 && runtime.WaitCalls() == 1 && runtime.BeginCalls() == 0,
+           "Async establishment did not submit exactly one End and one worker Wait");
+    Expect(runtime.MaxConcurrentWaits() == 1,
+           "Async establishment allowed concurrent downstream xrWaitFrame calls");
+    Expect(handoff.armed == 1 && handoff.wait_intercepts == 1 &&
+               handoff.begin_intercepts == 1 && handoff.cancellations == 0,
+           "Async handoff diagnostics did not describe the protected window");
+    Expect(runtime.ValidStructs(), "Layer sent malformed frame structures to the fake runtime");
+}
+
+void TestAsyncSecondPollWaitsForPublishedRuntimeWait() {
+    FakeRuntime runtime;
+    runtime.BlockEnd();
+    runtime.BlockWait();
+    TurboHarness harness(runtime, depthxr::TurboPacingMode::kAsync);
+    const XrFrameEndInfo end_info = FrameEndInfo();
+
+    auto end_result = std::async(std::launch::async, [&] {
+        return depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info);
+    });
+    Expect(runtime.WaitForEndEntered(1), "Second-poll test never entered runtime xrEndFrame");
+
+    XrFrameState first_state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&first_state) == XR_SUCCESS && AppBegin() == XR_SUCCESS,
+           "First app poll was not fabricated during async handoff");
+
+    auto second_wait = std::async(std::launch::async, [] {
+        XrFrameState state{XR_TYPE_FRAME_STATE};
+        return AppWait(&state);
+    });
+    Expect(WaitForSecondPollBlock(), "Second app poll did not block on handoff publication");
+    Expect(second_wait.wait_for(30ms) == std::future_status::timeout,
+           "Second app poll returned before the runtime wait was published");
+
+    runtime.ReleaseEnd();
+    Expect(runtime.WaitForWaitEntered(1), "Published async worker wait never reached the runtime");
+    Expect(second_wait.wait_for(30ms) == std::future_status::timeout,
+           "Second app poll returned before the published runtime wait completed");
+    runtime.ReleaseWait();
+
+    Expect(end_result.wait_for(2s) == std::future_status::ready && end_result.get() == XR_SUCCESS,
+           "Second-poll test xrEndFrame did not complete");
+    Expect(second_wait.wait_for(2s) == std::future_status::ready && second_wait.get() == XR_SUCCESS,
+           "Second app poll did not resume after the runtime wait completed");
+    const auto handoff = depthxr::TurboFrameTestPeer::Handoff();
+    Expect(handoff.second_poll_blocks == 1 && runtime.WaitCalls() == 1 &&
+               runtime.MaxConcurrentWaits() == 1,
+           "Second-poll guard did not preserve the one-runtime-wait invariant");
+}
+
+void TestAsyncSubmitFailureCancelsHandoff() {
+    FakeRuntime runtime;
+    runtime.BlockEnd();
+    runtime.SetEndResult(XR_ERROR_RUNTIME_FAILURE);
+    TurboHarness harness(runtime, depthxr::TurboPacingMode::kAsync);
+    const XrFrameEndInfo end_info = FrameEndInfo();
+
+    auto end_result = std::async(std::launch::async, [&] {
+        return depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info);
+    });
+    Expect(runtime.WaitForEndEntered(1), "Failure test never entered runtime xrEndFrame");
+    XrFrameState first_state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&first_state) == XR_SUCCESS && AppBegin() == XR_SUCCESS,
+           "Failure test did not intercept the first app frame calls");
+
+    auto second_wait = std::async(std::launch::async, [] {
+        XrFrameState state{XR_TYPE_FRAME_STATE};
+        return AppWait(&state);
+    });
+    Expect(WaitForSecondPollBlock(), "Failure test's second poll never waited for publication");
+    runtime.ReleaseEnd();
+
+    Expect(end_result.wait_for(2s) == std::future_status::ready &&
+               end_result.get() == XR_ERROR_RUNTIME_FAILURE,
+           "Runtime xrEndFrame failure was not returned to the application");
+    Expect(second_wait.wait_for(2s) == std::future_status::ready && second_wait.get() == XR_SUCCESS,
+           "Cancelled handoff did not return the second app poll to runtime pacing");
+    const auto handoff = depthxr::TurboFrameTestPeer::Handoff();
+    Expect(!handoff.active && !handoff.wait_valid && handoff.cancellations == 1,
+           "Failed submit did not cancel the unpublished async handoff exactly once");
+    Expect(runtime.WaitCalls() == 1 && runtime.MaxConcurrentWaits() == 1,
+           "Cancelled handoff launched a worker wait or duplicated the app's runtime wait");
+}
+
+void TestSequencedHandshakeAndSteadyStateOrdering() {
+    FakeRuntime runtime;
+    TurboHarness harness(runtime, depthxr::TurboPacingMode::kSequenced);
+    const XrFrameEndInfo end_info = FrameEndInfo();
+
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Sequenced establishment submit failed");
+    Expect(depthxr::TurboFrameTestPeer::SequencedState() ==
+               depthxr::TurboFrameTestPeer::EngagingState(),
+           "Sequenced mode did not enter its app-wait handshake");
+
+    XrFrameState handshake_state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&handshake_state) == XR_SUCCESS && AppBegin() == XR_SUCCESS,
+           "Sequenced establishment did not pass the app's wait/begin through");
+    Expect(depthxr::TurboFrameTestPeer::SequencedState() ==
+               depthxr::TurboFrameTestPeer::ActiveState(),
+           "Sequenced handshake did not activate the persistent interception shield");
+
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Sequenced steady-state submit failed");
+    Expect(runtime.EndCalls() == 2 && runtime.WaitCalls() == 2 && runtime.BeginCalls() == 2,
+           "Sequenced runtime did not receive one wait/begin pair after each applicable submit");
+
+    const int waits_before_app_poll = runtime.WaitCalls();
+    const int begins_before_app_poll = runtime.BeginCalls();
+    XrFrameState fabricated_state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&fabricated_state) == XR_SUCCESS && AppBegin() == XR_SUCCESS,
+           "Sequenced steady-state app frame calls were not fabricated");
+    Expect(runtime.WaitCalls() == waits_before_app_poll &&
+               runtime.BeginCalls() == begins_before_app_poll,
+           "Sequenced steady-state app calls escaped the interception shield");
+
+    const std::vector<RuntimeCall> expected{
+        RuntimeCall::kEnd,
+        RuntimeCall::kWait,
+        RuntimeCall::kBegin,
+        RuntimeCall::kEnd,
+        RuntimeCall::kWait,
+        RuntimeCall::kBegin,
+    };
+    Expect(runtime.Calls() == expected,
+           "Sequenced runtime ordering was not End -> Wait -> Begin in steady state");
+    Expect(runtime.MaxConcurrentWaits() == 1 && runtime.ValidStructs(),
+           "Sequenced mode duplicated a runtime wait or sent malformed frame structures");
+}
+
+void TestSubmissionInterlockFallsBackThenSuspends() {
+    FakeRuntime runtime;
+    runtime.BlockWait();
+    TurboHarness harness(runtime, depthxr::TurboPacingMode::kAsync);
+    depthxr::TurboFrameTestPeer::SetPolicy(depthxr::TurboPacingMode::kAsync,
+                                          depthxr::TurboFrameTestPeer::Source::kProbing);
+    const XrFrameEndInfo end_info = FrameEndInfo();
+
+    // Establish an async worker wait that behaves like a runtime whose wait is
+    // released only by the following submit (PiOpenXR/Oculus/Varjo profile).
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Interlock test could not establish async pacing");
+    Expect(runtime.WaitForWaitEntered(1), "Interlock profile never received its first worker wait");
+    runtime.ReleaseWaitOnNextEnd();
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "First interlocked async submit failed");
+    Expect(runtime.WaitForWaitExited(1), "First interlocked wait did not release on submit");
+    Expect(depthxr::TurboFrameTestPeer::PacingMode() == depthxr::TurboPacingMode::kAsync,
+           "Auto pacing abandoned async before its probing threshold");
+
+    // Retire the completed future and launch the second blocked worker wait.
+    runtime.BlockWait();
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Interlock test could not launch its second worker wait");
+    Expect(runtime.WaitForWaitEntered(2), "Interlock profile never received its second worker wait");
+    runtime.ReleaseWaitOnNextEnd();
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Second interlocked async submit failed");
+    Expect(runtime.WaitForWaitExited(2), "Second interlocked wait did not release on submit");
+    Expect(depthxr::TurboFrameTestPeer::PacingMode() == depthxr::TurboPacingMode::kSequenced,
+           "Auto pacing did not fall back to sequenced after two probing stalls");
+
+    // The next submit retires the final async future and establishes the
+    // sequenced handshake; this verifies the two strategies compose cleanly.
+    Expect(depthxr::TurboFrameTestPeer::ForwardEndFrame(TestSession(), &end_info) == XR_SUCCESS,
+           "Async-to-sequenced transition submit failed");
+    Expect(depthxr::TurboFrameTestPeer::SequencedState() ==
+               depthxr::TurboFrameTestPeer::EngagingState(),
+           "Async-to-sequenced transition did not enter the handshake state");
+    XrFrameState state{XR_TYPE_FRAME_STATE};
+    Expect(AppWait(&state) == XR_SUCCESS && AppBegin() == XR_SUCCESS,
+           "Fallback sequenced handshake failed");
+
+    // Level two of the policy suspends Turbo when even post-submit sequenced
+    // waits repeatedly stall. Drive the policy clock directly so the test is
+    // fast and independent of host scheduling.
+    depthxr::TurboFrameTestPeer::SetPolicy(depthxr::TurboPacingMode::kSequenced,
+                                          depthxr::TurboFrameTestPeer::Source::kFallback);
+    const auto now = std::chrono::steady_clock::now();
+    Expect(!depthxr::TurboFrameTestPeer::HandleTimeout(now),
+           "Sequenced pacing suspended on its first stall");
+    Expect(!depthxr::TurboFrameTestPeer::HandleTimeout(now + 1ms),
+           "Sequenced pacing suspended before its three-stall threshold");
+    Expect(depthxr::TurboFrameTestPeer::HandleTimeout(now + 2ms) &&
+               depthxr::TurboFrameTestPeer::AutoSuspended(),
+           "Sequenced pacing did not auto-suspend at its safety threshold");
+    Expect(runtime.MaxConcurrentWaits() == 1,
+           "Interlocked runtime profile observed concurrent downstream waits");
+}
+
+} // namespace
+
+int main() {
+    TestAsyncHandoffCoversEndFrameWindow();
+    TestAsyncSecondPollWaitsForPublishedRuntimeWait();
+    TestAsyncSubmitFailureCancelsHandoff();
+    TestSequencedHandshakeAndSteadyStateOrdering();
+    TestSubmissionInterlockFallsBackThenSuspends();
+    std::cout << "depthxr_turbo_frame_tests passed\n";
+    return 0;
+}

--- a/layer/tools/pivot_space_probe.cpp
+++ b/layer/tools/pivot_space_probe.cpp
@@ -219,6 +219,95 @@ bool NearlyIdentity(const XrPosef& pose) {
            NearlyEqual(pose.position.z, 0.0f);
 }
 
+bool IsTypelessFormat(DXGI_FORMAT format) {
+    switch (format) {
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R16G16_TYPELESS:
+    case DXGI_FORMAT_R32_TYPELESS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+DXGI_FORMAT ResolveRenderTargetFormat(DXGI_FORMAT texture_format,
+                                      int64_t requested_format) {
+    if (!IsTypelessFormat(texture_format)) {
+        return texture_format;
+    }
+    const DXGI_FORMAT requested = static_cast<DXGI_FORMAT>(requested_format);
+    if (requested != DXGI_FORMAT_UNKNOWN && !IsTypelessFormat(requested)) {
+        return requested;
+    }
+    switch (texture_format) {
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8X8_UNORM;
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        return DXGI_FORMAT_R16G16B16A16_FLOAT;
+    case DXGI_FORMAT_R16G16_TYPELESS:
+        return DXGI_FORMAT_R16G16_UNORM;
+    case DXGI_FORMAT_R32_TYPELESS:
+        return DXGI_FORMAT_R32_FLOAT;
+    default:
+        return texture_format;
+    }
+}
+
+void CreateSwapchainRenderTarget(ID3D11Device* device,
+                                 ID3D11Texture2D* texture,
+                                 int64_t requested_format,
+                                 ID3D11RenderTargetView** render_target) {
+    D3D11_TEXTURE2D_DESC texture_desc{};
+    texture->GetDesc(&texture_desc);
+
+    D3D11_RENDER_TARGET_VIEW_DESC view_desc{};
+    view_desc.Format = ResolveRenderTargetFormat(
+        texture_desc.Format, requested_format);
+    if (texture_desc.SampleDesc.Count > 1 && texture_desc.ArraySize > 1) {
+        view_desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
+        view_desc.Texture2DMSArray.FirstArraySlice = 0;
+        view_desc.Texture2DMSArray.ArraySize = 1;
+    } else if (texture_desc.SampleDesc.Count > 1) {
+        view_desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMS;
+    } else if (texture_desc.ArraySize > 1) {
+        view_desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+        view_desc.Texture2DArray.MipSlice = 0;
+        view_desc.Texture2DArray.FirstArraySlice = 0;
+        view_desc.Texture2DArray.ArraySize = 1;
+    } else {
+        view_desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+        view_desc.Texture2D.MipSlice = 0;
+    }
+
+    const HRESULT result = device->CreateRenderTargetView(
+        texture, &view_desc, render_target);
+    if (FAILED(result)) {
+        std::ostringstream stream;
+        stream << "CreateRenderTargetView failed with HRESULT 0x" << std::hex
+               << static_cast<uint32_t>(result) << std::dec
+               << "; requestedFormat=" << requested_format
+               << ", texture={size=" << texture_desc.Width << "x" << texture_desc.Height
+               << ", mips=" << texture_desc.MipLevels
+               << ", array=" << texture_desc.ArraySize
+               << ", format=" << static_cast<uint32_t>(texture_desc.Format)
+               << ", samples=" << texture_desc.SampleDesc.Count
+               << ", bindFlags=0x" << std::hex << texture_desc.BindFlags << std::dec
+               << "}, viewFormat=" << static_cast<uint32_t>(view_desc.Format)
+               << ", viewDimension=" << static_cast<uint32_t>(view_desc.ViewDimension);
+        throw std::runtime_error(stream.str());
+    }
+}
+
 void RunSelfTest() {
     constexpr float kPi = 3.14159265358979323846f;
     const float half_yaw = 0.5f * kPi / 2.0f;
@@ -235,6 +324,18 @@ void RunSelfTest() {
     const XrPosef error = ComposePose(InvertPose(view), round_trip);
     if (!NearlyIdentity(error)) {
         throw std::runtime_error("pose composition round-trip failed");
+    }
+    if (ResolveRenderTargetFormat(
+            DXGI_FORMAT_R8G8B8A8_TYPELESS,
+            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB) !=
+        DXGI_FORMAT_R8G8B8A8_UNORM_SRGB) {
+        throw std::runtime_error("typeless swapchain RTV format resolution failed");
+    }
+    if (ResolveRenderTargetFormat(
+            DXGI_FORMAT_B8G8R8A8_UNORM,
+            DXGI_FORMAT_R8G8B8A8_UNORM) !=
+        DXGI_FORMAT_B8G8R8A8_UNORM) {
+        throw std::runtime_error("typed swapchain RTV format preservation failed");
     }
     std::cout << "vectorxr_hardware_probe self-test passed\n";
 }
@@ -844,10 +945,9 @@ private:
                     "xrEnumerateSwapchainImages");
             swapchain.render_targets.resize(image_count);
             for (uint32_t image = 0; image < image_count; ++image) {
-                ThrowIfFailed(device_->CreateRenderTargetView(
-                                  swapchain.images[image].texture, nullptr,
-                                  &swapchain.render_targets[image]),
-                              "CreateRenderTargetView");
+                CreateSwapchainRenderTarget(
+                    device_.Get(), swapchain.images[image].texture,
+                    swapchain.format, &swapchain.render_targets[image]);
             }
 
             D3D11_TEXTURE2D_DESC depth_desc{};

--- a/layer/tools/pivot_space_probe.cpp
+++ b/layer/tools/pivot_space_probe.cpp
@@ -1,0 +1,1174 @@
+#include <Windows.h>
+#include <d3d11.h>
+#include <d3dcompiler.h>
+#include <dxgi1_2.h>
+#include <DirectXMath.h>
+#include <wrl/client.h>
+
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+using Microsoft::WRL::ComPtr;
+using namespace DirectX;
+
+namespace {
+
+constexpr XrViewConfigurationType kViewConfiguration =
+    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+constexpr float kNearZ = 0.05f;
+constexpr float kFarZ = 100.0f;
+constexpr uint32_t kMaximumEyeDimension = 1280;
+
+enum class ProbeMode {
+    SourceExact,
+    CrossSpace,
+    CrossSpaceCached,
+};
+
+struct Options {
+    ProbeMode mode{ProbeMode::CrossSpace};
+    double seconds{20.0};
+    bool threaded_wait{false};
+    bool self_test{false};
+    bool help{false};
+};
+
+const char* ModeName(ProbeMode mode) {
+    switch (mode) {
+    case ProbeMode::SourceExact:
+        return "source-exact";
+    case ProbeMode::CrossSpace:
+        return "cross-space";
+    case ProbeMode::CrossSpaceCached:
+        return "cross-space-cached";
+    }
+    return "unknown";
+}
+
+void PrintUsage() {
+    std::cout
+        << "VectorXR real-runtime Pivot space probe\n\n"
+        << "Usage:\n"
+        << "  vectorxr_hardware_probe [options]\n\n"
+        << "Options:\n"
+        << "  --mode source-exact|cross-space|cross-space-cached\n"
+        << "      source-exact        Locate and submit in source LOCAL space.\n"
+        << "      cross-space         Locate in source LOCAL, submit in an offset LOCAL space.\n"
+        << "      cross-space-cached  Also locate the offset space at the same display time.\n"
+        << "  --seconds N             Active render duration (default: 20).\n"
+        << "  --threaded-wait         Overlap the next xrWaitFrame with the current xrEndFrame.\n"
+        << "  --self-test             Validate argument-independent pose math without a headset.\n"
+        << "  --help                  Show this help.\n\n"
+        << "Press Escape in the console window to end an active run early.\n";
+}
+
+Options ParseOptions(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument = argv[i];
+        if (argument == "--help" || argument == "-h") {
+            options.help = true;
+        } else if (argument == "--self-test") {
+            options.self_test = true;
+        } else if (argument == "--threaded-wait") {
+            options.threaded_wait = true;
+        } else if (argument == "--mode") {
+            if (++i >= argc) {
+                throw std::runtime_error("--mode requires a value");
+            }
+            const std::string_view value = argv[i];
+            if (value == "source-exact") {
+                options.mode = ProbeMode::SourceExact;
+            } else if (value == "cross-space") {
+                options.mode = ProbeMode::CrossSpace;
+            } else if (value == "cross-space-cached") {
+                options.mode = ProbeMode::CrossSpaceCached;
+            } else {
+                throw std::runtime_error("unknown --mode value: " + std::string(value));
+            }
+        } else if (argument == "--seconds") {
+            if (++i >= argc) {
+                throw std::runtime_error("--seconds requires a value");
+            }
+            options.seconds = std::stod(argv[i]);
+            if (!std::isfinite(options.seconds) || options.seconds <= 0.0 ||
+                options.seconds > 3600.0) {
+                throw std::runtime_error("--seconds must be between 0 and 3600");
+            }
+        } else {
+            throw std::runtime_error("unknown argument: " + std::string(argument));
+        }
+    }
+    return options;
+}
+
+void ThrowIfFailed(HRESULT result, std::string_view operation) {
+    if (FAILED(result)) {
+        std::ostringstream stream;
+        stream << operation << " failed with HRESULT 0x" << std::hex
+               << static_cast<uint32_t>(result);
+        throw std::runtime_error(stream.str());
+    }
+}
+
+void CheckXr(XrInstance instance, XrResult result, std::string_view operation) {
+    if (XR_SUCCEEDED(result)) {
+        return;
+    }
+    char result_text[XR_MAX_RESULT_STRING_SIZE]{};
+    if (instance != XR_NULL_HANDLE) {
+        xrResultToString(instance, result, result_text);
+    }
+    std::ostringstream stream;
+    stream << operation << " failed: " << static_cast<int32_t>(result);
+    if (result_text[0] != '\0') {
+        stream << " (" << result_text << ")";
+    }
+    throw std::runtime_error(stream.str());
+}
+
+XrPosef IdentityPose() {
+    return {{0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f}};
+}
+
+XrQuaternionf NormalizeQuaternion(const XrQuaternionf& quaternion) {
+    const float magnitude = std::sqrt(
+        quaternion.x * quaternion.x + quaternion.y * quaternion.y +
+        quaternion.z * quaternion.z + quaternion.w * quaternion.w);
+    if (magnitude <= 1.0e-8f) {
+        return IdentityPose().orientation;
+    }
+    return {quaternion.x / magnitude, quaternion.y / magnitude,
+            quaternion.z / magnitude, quaternion.w / magnitude};
+}
+
+XrQuaternionf MultiplyQuaternion(const XrQuaternionf& lhs,
+                                 const XrQuaternionf& rhs) {
+    return NormalizeQuaternion({
+        lhs.w * rhs.x + lhs.x * rhs.w + lhs.y * rhs.z - lhs.z * rhs.y,
+        lhs.w * rhs.y - lhs.x * rhs.z + lhs.y * rhs.w + lhs.z * rhs.x,
+        lhs.w * rhs.z + lhs.x * rhs.y - lhs.y * rhs.x + lhs.z * rhs.w,
+        lhs.w * rhs.w - lhs.x * rhs.x - lhs.y * rhs.y - lhs.z * rhs.z,
+    });
+}
+
+XrVector3f RotateVector(const XrQuaternionf& rotation, const XrVector3f& vector) {
+    const XMVECTOR quaternion = XMVectorSet(
+        rotation.x, rotation.y, rotation.z, rotation.w);
+    const XMVECTOR source = XMVectorSet(vector.x, vector.y, vector.z, 0.0f);
+    XMFLOAT3 rotated{};
+    XMStoreFloat3(&rotated, XMVector3Rotate(source, quaternion));
+    return {rotated.x, rotated.y, rotated.z};
+}
+
+// Conventional rigid composition: parent_in_world * local_in_parent.
+XrPosef ComposePose(const XrPosef& parent, const XrPosef& local) {
+    const XrVector3f rotated = RotateVector(parent.orientation, local.position);
+    return {
+        MultiplyQuaternion(parent.orientation, local.orientation),
+        {parent.position.x + rotated.x,
+         parent.position.y + rotated.y,
+         parent.position.z + rotated.z},
+    };
+}
+
+XrPosef InvertPose(const XrPosef& pose) {
+    const XrQuaternionf inverse_rotation =
+        NormalizeQuaternion({-pose.orientation.x, -pose.orientation.y,
+                             -pose.orientation.z, pose.orientation.w});
+    const XrVector3f inverse_position = RotateVector(
+        inverse_rotation,
+        {-pose.position.x, -pose.position.y, -pose.position.z});
+    return {inverse_rotation, inverse_position};
+}
+
+bool NearlyEqual(float lhs, float rhs, float epsilon = 1.0e-4f) {
+    return std::abs(lhs - rhs) <= epsilon;
+}
+
+bool NearlyIdentity(const XrPosef& pose) {
+    return NearlyEqual(pose.orientation.x, 0.0f) &&
+           NearlyEqual(pose.orientation.y, 0.0f) &&
+           NearlyEqual(pose.orientation.z, 0.0f) &&
+           NearlyEqual(std::abs(pose.orientation.w), 1.0f) &&
+           NearlyEqual(pose.position.x, 0.0f) &&
+           NearlyEqual(pose.position.y, 0.0f) &&
+           NearlyEqual(pose.position.z, 0.0f);
+}
+
+void RunSelfTest() {
+    constexpr float kPi = 3.14159265358979323846f;
+    const float half_yaw = 0.5f * kPi / 2.0f;
+    const XrPosef target{
+        {0.0f, std::sin(half_yaw), 0.0f, std::cos(half_yaw)},
+        {1.25f, 0.35f, -0.75f},
+    };
+    const XrPosef view{
+        NormalizeQuaternion({0.11f, -0.23f, 0.07f, 0.96f}),
+        {-0.4f, 1.6f, -2.5f},
+    };
+    const XrPosef transformed = ComposePose(target, view);
+    const XrPosef round_trip = ComposePose(InvertPose(target), transformed);
+    const XrPosef error = ComposePose(InvertPose(view), round_trip);
+    if (!NearlyIdentity(error)) {
+        throw std::runtime_error("pose composition round-trip failed");
+    }
+    std::cout << "vectorxr_hardware_probe self-test passed\n";
+}
+
+struct Vertex {
+    XMFLOAT3 position;
+    XMFLOAT3 color;
+};
+
+struct SceneConstants {
+    XMFLOAT4X4 view_projection;
+};
+
+class DiagnosticRenderer {
+public:
+    void Initialize(ID3D11Device* device, ID3D11DeviceContext* context) {
+        device_ = device;
+        context_ = context;
+
+        static constexpr char kShaderSource[] = R"(
+cbuffer SceneConstants : register(b0) {
+    row_major float4x4 viewProjection;
+};
+
+struct VertexInput {
+    float3 position : POSITION;
+    float3 color : COLOR0;
+};
+
+struct VertexOutput {
+    float4 position : SV_POSITION;
+    float3 color : COLOR0;
+};
+
+VertexOutput VSMain(VertexInput input) {
+    VertexOutput output;
+    output.position = mul(float4(input.position, 1.0), viewProjection);
+    output.color = input.color;
+    return output;
+}
+
+float4 PSMain(VertexOutput input) : SV_TARGET {
+    return float4(input.color, 1.0);
+}
+)";
+
+        ComPtr<ID3DBlob> vertex_blob;
+        ComPtr<ID3DBlob> pixel_blob;
+        CompileShader(kShaderSource, "VSMain", "vs_5_0", &vertex_blob);
+        CompileShader(kShaderSource, "PSMain", "ps_5_0", &pixel_blob);
+        ThrowIfFailed(device_->CreateVertexShader(
+                          vertex_blob->GetBufferPointer(), vertex_blob->GetBufferSize(),
+                          nullptr, &vertex_shader_),
+                      "CreateVertexShader");
+        ThrowIfFailed(device_->CreatePixelShader(
+                          pixel_blob->GetBufferPointer(), pixel_blob->GetBufferSize(),
+                          nullptr, &pixel_shader_),
+                      "CreatePixelShader");
+
+        const D3D11_INPUT_ELEMENT_DESC elements[] = {
+            {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,
+             static_cast<UINT>(offsetof(Vertex, position)),
+             D3D11_INPUT_PER_VERTEX_DATA, 0},
+            {"COLOR", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,
+             static_cast<UINT>(offsetof(Vertex, color)),
+             D3D11_INPUT_PER_VERTEX_DATA, 0},
+        };
+        ThrowIfFailed(device_->CreateInputLayout(
+                          elements, static_cast<UINT>(std::size(elements)),
+                          vertex_blob->GetBufferPointer(), vertex_blob->GetBufferSize(),
+                          &input_layout_),
+                      "CreateInputLayout");
+
+        const std::vector<Vertex> vertices = BuildScene();
+        vertex_count_ = static_cast<UINT>(vertices.size());
+        D3D11_BUFFER_DESC vertex_desc{};
+        vertex_desc.ByteWidth = static_cast<UINT>(vertices.size() * sizeof(Vertex));
+        vertex_desc.Usage = D3D11_USAGE_IMMUTABLE;
+        vertex_desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+        D3D11_SUBRESOURCE_DATA vertex_data{};
+        vertex_data.pSysMem = vertices.data();
+        ThrowIfFailed(device_->CreateBuffer(&vertex_desc, &vertex_data, &vertex_buffer_),
+                      "CreateBuffer(vertex)");
+
+        D3D11_BUFFER_DESC constant_desc{};
+        constant_desc.ByteWidth = sizeof(SceneConstants);
+        constant_desc.Usage = D3D11_USAGE_DYNAMIC;
+        constant_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+        constant_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        ThrowIfFailed(device_->CreateBuffer(&constant_desc, nullptr, &constant_buffer_),
+                      "CreateBuffer(constants)");
+
+        D3D11_DEPTH_STENCIL_DESC depth_state_desc{};
+        depth_state_desc.DepthEnable = TRUE;
+        depth_state_desc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
+        depth_state_desc.DepthFunc = D3D11_COMPARISON_LESS;
+        ThrowIfFailed(device_->CreateDepthStencilState(&depth_state_desc, &depth_state_),
+                      "CreateDepthStencilState");
+    }
+
+    void Render(ID3D11RenderTargetView* render_target,
+                ID3D11DepthStencilView* depth_target,
+                uint32_t width,
+                uint32_t height,
+                const XrPosef& view_pose,
+                const XrFovf& fov,
+                uint32_t eye) {
+        const float clear_color[4] = {
+            eye == 0 ? 0.015f : 0.025f,
+            0.02f,
+            eye == 0 ? 0.03f : 0.015f,
+            1.0f,
+        };
+        context_->ClearRenderTargetView(render_target, clear_color);
+        context_->ClearDepthStencilView(depth_target, D3D11_CLEAR_DEPTH, 1.0f, 0);
+
+        const XMVECTOR orientation = XMVectorSet(
+            view_pose.orientation.x, view_pose.orientation.y,
+            view_pose.orientation.z, view_pose.orientation.w);
+        const XMMATRIX world_from_view =
+            XMMatrixRotationQuaternion(orientation) *
+            XMMatrixTranslation(view_pose.position.x,
+                                view_pose.position.y,
+                                view_pose.position.z);
+        const XMMATRIX view_from_world = XMMatrixInverse(nullptr, world_from_view);
+        const float left = std::tan(fov.angleLeft) * kNearZ;
+        const float right = std::tan(fov.angleRight) * kNearZ;
+        const float bottom = std::tan(fov.angleDown) * kNearZ;
+        const float top = std::tan(fov.angleUp) * kNearZ;
+        const XMMATRIX projection = XMMatrixPerspectiveOffCenterRH(
+            left, right, bottom, top, kNearZ, kFarZ);
+
+        SceneConstants constants{};
+        XMStoreFloat4x4(&constants.view_projection, view_from_world * projection);
+        D3D11_MAPPED_SUBRESOURCE mapped{};
+        ThrowIfFailed(context_->Map(constant_buffer_.Get(), 0,
+                                    D3D11_MAP_WRITE_DISCARD, 0, &mapped),
+                      "Map(constants)");
+        std::memcpy(mapped.pData, &constants, sizeof(constants));
+        context_->Unmap(constant_buffer_.Get(), 0);
+
+        D3D11_VIEWPORT viewport{};
+        viewport.Width = static_cast<float>(width);
+        viewport.Height = static_cast<float>(height);
+        viewport.MinDepth = 0.0f;
+        viewport.MaxDepth = 1.0f;
+        context_->RSSetViewports(1, &viewport);
+        context_->OMSetRenderTargets(1, &render_target, depth_target);
+        context_->OMSetDepthStencilState(depth_state_.Get(), 0);
+        context_->IASetInputLayout(input_layout_.Get());
+        context_->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
+        const UINT stride = sizeof(Vertex);
+        const UINT offset = 0;
+        ID3D11Buffer* vertex_buffer = vertex_buffer_.Get();
+        context_->IASetVertexBuffers(0, 1, &vertex_buffer, &stride, &offset);
+        context_->VSSetShader(vertex_shader_.Get(), nullptr, 0);
+        ID3D11Buffer* constant_buffer = constant_buffer_.Get();
+        context_->VSSetConstantBuffers(0, 1, &constant_buffer);
+        context_->PSSetShader(pixel_shader_.Get(), nullptr, 0);
+        context_->Draw(vertex_count_, 0);
+    }
+
+private:
+    static void CompileShader(const char* source,
+                              const char* entry,
+                              const char* profile,
+                              ID3DBlob** output) {
+        ComPtr<ID3DBlob> errors;
+        const HRESULT result = D3DCompile(
+            source, std::strlen(source), "pivot_space_probe.hlsl", nullptr, nullptr,
+            entry, profile, D3DCOMPILE_OPTIMIZATION_LEVEL3, 0, output, &errors);
+        if (FAILED(result)) {
+            const std::string detail = errors
+                ? std::string(static_cast<const char*>(errors->GetBufferPointer()),
+                              errors->GetBufferSize())
+                : std::string{};
+            throw std::runtime_error("D3DCompile failed for " + std::string(entry) +
+                                     ": " + detail);
+        }
+    }
+
+    static std::vector<Vertex> BuildScene() {
+        std::vector<Vertex> vertices;
+        const auto line = [&](XMFLOAT3 start, XMFLOAT3 end, XMFLOAT3 color) {
+            vertices.push_back({start, color});
+            vertices.push_back({end, color});
+        };
+
+        const XMFLOAT3 grid{0.18f, 0.22f, 0.27f};
+        for (int x = -10; x <= 10; ++x) {
+            line({static_cast<float>(x), -1.5f, -1.0f},
+                 {static_cast<float>(x), -1.5f, -21.0f}, grid);
+        }
+        for (int z = 1; z <= 21; ++z) {
+            line({-10.0f, -1.5f, -static_cast<float>(z)},
+                 {10.0f, -1.5f, -static_cast<float>(z)}, grid);
+        }
+
+        const XMFLOAT3 origin{0.0f, -1.5f, -4.0f};
+        line(origin, {2.5f, -1.5f, -4.0f}, {1.0f, 0.1f, 0.1f});
+        line(origin, {0.0f, 1.0f, -4.0f}, {0.1f, 1.0f, 0.1f});
+        line(origin, {0.0f, -1.5f, -7.0f}, {0.1f, 0.35f, 1.0f});
+
+        const auto beacon = [&](float x, float z, XMFLOAT3 color) {
+            line({x, -1.5f, z}, {x, 2.5f, z}, color);
+            line({x - 0.4f, 2.1f, z}, {x + 0.4f, 2.1f, z}, color);
+            line({x, 1.7f, z - 0.4f}, {x, 1.7f, z + 0.4f}, color);
+        };
+        beacon(-3.0f, -7.0f, {1.0f, 0.85f, 0.1f});
+        beacon(4.0f, -12.0f, {1.0f, 0.1f, 0.85f});
+        return vertices;
+    }
+
+    ID3D11Device* device_{nullptr};
+    ID3D11DeviceContext* context_{nullptr};
+    ComPtr<ID3D11VertexShader> vertex_shader_;
+    ComPtr<ID3D11PixelShader> pixel_shader_;
+    ComPtr<ID3D11InputLayout> input_layout_;
+    ComPtr<ID3D11Buffer> vertex_buffer_;
+    ComPtr<ID3D11Buffer> constant_buffer_;
+    ComPtr<ID3D11DepthStencilState> depth_state_;
+    UINT vertex_count_{0};
+};
+
+struct EyeSwapchain {
+    XrSwapchain handle{XR_NULL_HANDLE};
+    uint32_t width{0};
+    uint32_t height{0};
+    int64_t format{0};
+    std::vector<XrSwapchainImageD3D11KHR> images;
+    std::vector<ComPtr<ID3D11RenderTargetView>> render_targets;
+    ComPtr<ID3D11Texture2D> depth_texture;
+    ComPtr<ID3D11DepthStencilView> depth_target;
+};
+
+struct WaitedFrame {
+    XrResult result{XR_SUCCESS};
+    XrFrameState state{XR_TYPE_FRAME_STATE};
+};
+
+class WaitFrameWorker {
+public:
+    explicit WaitFrameWorker(XrSession session) : session_(session) {
+        thread_ = std::thread([this] { Run(); });
+    }
+
+    ~WaitFrameWorker() {
+        {
+            std::scoped_lock lock(mutex_);
+            stop_ = true;
+        }
+        condition_.notify_all();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    void Request() {
+        std::scoped_lock lock(mutex_);
+        if (requested_ || result_ready_) {
+            throw std::runtime_error("threaded xrWaitFrame request overlapped another request");
+        }
+        call_started_ = false;
+        requested_ = true;
+        condition_.notify_all();
+    }
+
+    void WaitUntilCallStarted() {
+        std::unique_lock lock(mutex_);
+        condition_.wait(lock, [this] { return call_started_ || result_ready_ || stop_; });
+        if (!call_started_ && !result_ready_) {
+            throw std::runtime_error("threaded xrWaitFrame worker stopped before entering the call");
+        }
+    }
+
+    WaitedFrame Wait() {
+        std::unique_lock lock(mutex_);
+        condition_.wait(lock, [this] { return result_ready_ || stop_; });
+        if (!result_ready_) {
+            throw std::runtime_error("threaded xrWaitFrame worker stopped without a result");
+        }
+        WaitedFrame result = result_;
+        result_ready_ = false;
+        return result;
+    }
+
+private:
+    void Run() {
+        for (;;) {
+            {
+                std::unique_lock lock(mutex_);
+                condition_.wait(lock, [this] { return requested_ || stop_; });
+                if (stop_) {
+                    return;
+                }
+                requested_ = false;
+                call_started_ = true;
+                condition_.notify_all();
+            }
+
+            WaitedFrame waited;
+            const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
+            waited.result = xrWaitFrame(session_, &wait_info, &waited.state);
+
+            {
+                std::scoped_lock lock(mutex_);
+                result_ = waited;
+                result_ready_ = true;
+            }
+            condition_.notify_all();
+        }
+    }
+
+    XrSession session_{XR_NULL_HANDLE};
+    std::thread thread_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool requested_{false};
+    bool call_started_{false};
+    bool result_ready_{false};
+    bool stop_{false};
+    WaitedFrame result_{};
+};
+
+class ProbeApp {
+public:
+    explicit ProbeApp(Options options) : options_(options) {}
+
+    ~ProbeApp() {
+        for (EyeSwapchain& swapchain : swapchains_) {
+            swapchain.depth_target.Reset();
+            swapchain.depth_texture.Reset();
+            swapchain.render_targets.clear();
+            swapchain.images.clear();
+            if (swapchain.handle != XR_NULL_HANDLE) {
+                xrDestroySwapchain(swapchain.handle);
+            }
+        }
+        swapchains_.clear();
+        renderer_.reset();
+        context_.Reset();
+        device_.Reset();
+        if (target_space_ != XR_NULL_HANDLE) {
+            xrDestroySpace(target_space_);
+        }
+        if (source_space_ != XR_NULL_HANDLE) {
+            xrDestroySpace(source_space_);
+        }
+        if (session_ != XR_NULL_HANDLE) {
+            xrDestroySession(session_);
+        }
+        if (instance_ != XR_NULL_HANDLE) {
+            xrDestroyInstance(instance_);
+        }
+    }
+
+    void Run() {
+        CreateInstance();
+        CreateSystemAndDevice();
+        CreateSession();
+        CreateSpaces();
+        CreateSwapchains();
+        WaitForSessionReady();
+
+        std::cout << "Probe active: mode=" << ModeName(options_.mode)
+                  << ", threadedWait=" << (options_.threaded_wait ? "yes" : "no")
+                  << ", duration=" << options_.seconds << "s\n"
+                  << "Use a Pivot profile with both yaw and pitch for the strongest visual test.\n";
+
+        RenderLoop();
+        RequestAndDrainExit();
+
+        std::cout << "Probe complete: frames=" << rendered_frames_
+                  << ", invalidViewFrames=" << invalid_view_frames_
+                  << ", spaceRelationFailures=" << space_relation_failures_ << "\n";
+    }
+
+private:
+    void CreateInstance() {
+        uint32_t extension_count = 0;
+        CheckXr(XR_NULL_HANDLE,
+                xrEnumerateInstanceExtensionProperties(nullptr, 0, &extension_count, nullptr),
+                "xrEnumerateInstanceExtensionProperties(count)");
+        std::vector<XrExtensionProperties> extensions(
+            extension_count, {XR_TYPE_EXTENSION_PROPERTIES});
+        CheckXr(XR_NULL_HANDLE,
+                xrEnumerateInstanceExtensionProperties(
+                    nullptr, extension_count, &extension_count, extensions.data()),
+                "xrEnumerateInstanceExtensionProperties");
+        const bool has_d3d11 = std::any_of(
+            extensions.begin(), extensions.end(), [](const XrExtensionProperties& extension) {
+                return std::strcmp(extension.extensionName,
+                                   XR_KHR_D3D11_ENABLE_EXTENSION_NAME) == 0;
+            });
+        if (!has_d3d11) {
+            throw std::runtime_error("active OpenXR runtime does not expose XR_KHR_D3D11_enable");
+        }
+
+        const char* enabled_extensions[] = {XR_KHR_D3D11_ENABLE_EXTENSION_NAME};
+        XrInstanceCreateInfo create_info{XR_TYPE_INSTANCE_CREATE_INFO};
+        strcpy_s(create_info.applicationInfo.applicationName,
+                 XR_MAX_APPLICATION_NAME_SIZE,
+                 "VectorXR Hardware Probe");
+        create_info.applicationInfo.applicationVersion = 1;
+        strcpy_s(create_info.applicationInfo.engineName,
+                 XR_MAX_ENGINE_NAME_SIZE,
+                 "VectorXR Probe");
+        create_info.applicationInfo.engineVersion = 1;
+        create_info.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+        create_info.enabledExtensionCount = 1;
+        create_info.enabledExtensionNames = enabled_extensions;
+        CheckXr(XR_NULL_HANDLE, xrCreateInstance(&create_info, &instance_),
+                "xrCreateInstance");
+
+        XrInstanceProperties properties{XR_TYPE_INSTANCE_PROPERTIES};
+        CheckXr(instance_, xrGetInstanceProperties(instance_, &properties),
+                "xrGetInstanceProperties");
+        std::cout << "Runtime: " << properties.runtimeName
+                  << " " << XR_VERSION_MAJOR(properties.runtimeVersion) << "."
+                  << XR_VERSION_MINOR(properties.runtimeVersion) << "."
+                  << XR_VERSION_PATCH(properties.runtimeVersion) << "\n";
+    }
+
+    void CreateSystemAndDevice() {
+        const XrSystemGetInfo system_info{
+            XR_TYPE_SYSTEM_GET_INFO, nullptr, XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY};
+        CheckXr(instance_, xrGetSystem(instance_, &system_info, &system_id_),
+                "xrGetSystem");
+
+        XrSystemProperties system_properties{XR_TYPE_SYSTEM_PROPERTIES};
+        CheckXr(instance_, xrGetSystemProperties(instance_, system_id_, &system_properties),
+                "xrGetSystemProperties");
+        std::cout << "System: " << system_properties.systemName << "\n";
+
+        PFN_xrGetD3D11GraphicsRequirementsKHR get_requirements = nullptr;
+        CheckXr(instance_, xrGetInstanceProcAddr(
+                               instance_, "xrGetD3D11GraphicsRequirementsKHR",
+                               reinterpret_cast<PFN_xrVoidFunction*>(&get_requirements)),
+                "xrGetInstanceProcAddr(xrGetD3D11GraphicsRequirementsKHR)");
+        XrGraphicsRequirementsD3D11KHR requirements{
+            XR_TYPE_GRAPHICS_REQUIREMENTS_D3D11_KHR};
+        CheckXr(instance_, get_requirements(instance_, system_id_, &requirements),
+                "xrGetD3D11GraphicsRequirementsKHR");
+
+        ComPtr<IDXGIFactory1> factory;
+        ThrowIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&factory)),
+                      "CreateDXGIFactory1");
+        ComPtr<IDXGIAdapter1> selected_adapter;
+        for (UINT index = 0;; ++index) {
+            ComPtr<IDXGIAdapter1> candidate;
+            if (factory->EnumAdapters1(index, &candidate) == DXGI_ERROR_NOT_FOUND) {
+                break;
+            }
+            DXGI_ADAPTER_DESC1 description{};
+            ThrowIfFailed(candidate->GetDesc1(&description), "IDXGIAdapter1::GetDesc1");
+            if (description.AdapterLuid.HighPart == requirements.adapterLuid.HighPart &&
+                description.AdapterLuid.LowPart == requirements.adapterLuid.LowPart) {
+                selected_adapter = candidate;
+                std::wcout << L"Graphics adapter: " << description.Description << L"\n";
+                break;
+            }
+        }
+        if (!selected_adapter) {
+            throw std::runtime_error("could not find the D3D11 adapter requested by the runtime");
+        }
+
+        const std::array<D3D_FEATURE_LEVEL, 7> feature_levels{
+            D3D_FEATURE_LEVEL_12_1, D3D_FEATURE_LEVEL_12_0,
+            D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0,
+            D3D_FEATURE_LEVEL_9_3,
+        };
+        D3D_FEATURE_LEVEL created_level{};
+        ThrowIfFailed(D3D11CreateDevice(
+                          selected_adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+                          D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                          feature_levels.data(), static_cast<UINT>(feature_levels.size()),
+                          D3D11_SDK_VERSION, &device_, &created_level, &context_),
+                      "D3D11CreateDevice");
+        if (created_level < requirements.minFeatureLevel) {
+            throw std::runtime_error("created D3D11 device does not meet the runtime feature-level requirement");
+        }
+    }
+
+    void CreateSession() {
+        XrGraphicsBindingD3D11KHR graphics_binding{
+            XR_TYPE_GRAPHICS_BINDING_D3D11_KHR};
+        graphics_binding.device = device_.Get();
+        XrSessionCreateInfo create_info{XR_TYPE_SESSION_CREATE_INFO};
+        create_info.next = &graphics_binding;
+        create_info.systemId = system_id_;
+        CheckXr(instance_, xrCreateSession(instance_, &create_info, &session_),
+                "xrCreateSession");
+
+        uint32_t blend_count = 0;
+        CheckXr(instance_, xrEnumerateEnvironmentBlendModes(
+                               instance_, system_id_, kViewConfiguration,
+                               0, &blend_count, nullptr),
+                "xrEnumerateEnvironmentBlendModes(count)");
+        std::vector<XrEnvironmentBlendMode> modes(blend_count);
+        CheckXr(instance_, xrEnumerateEnvironmentBlendModes(
+                               instance_, system_id_, kViewConfiguration,
+                               blend_count, &blend_count, modes.data()),
+                "xrEnumerateEnvironmentBlendModes");
+        const auto opaque = std::find(
+            modes.begin(), modes.end(), XR_ENVIRONMENT_BLEND_MODE_OPAQUE);
+        if (modes.empty()) {
+            throw std::runtime_error("runtime returned no environment blend modes");
+        }
+        blend_mode_ = opaque != modes.end() ? *opaque : modes.front();
+    }
+
+    void CreateSpaces() {
+        XrReferenceSpaceCreateInfo source_info{
+            XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+        source_info.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
+        source_info.poseInReferenceSpace = IdentityPose();
+        CheckXr(instance_, xrCreateReferenceSpace(session_, &source_info, &source_space_),
+                "xrCreateReferenceSpace(source LOCAL)");
+
+        constexpr float kPi = 3.14159265358979323846f;
+        const float half_angle = kPi / 4.0f;
+        XrReferenceSpaceCreateInfo target_info{
+            XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+        target_info.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
+        target_info.poseInReferenceSpace = {
+            {0.0f, std::sin(half_angle), 0.0f, std::cos(half_angle)},
+            {1.25f, 0.35f, -0.75f},
+        };
+        CheckXr(instance_, xrCreateReferenceSpace(session_, &target_info, &target_space_),
+                "xrCreateReferenceSpace(offset LOCAL)");
+    }
+
+    void CreateSwapchains() {
+        uint32_t view_count = 0;
+        CheckXr(instance_, xrEnumerateViewConfigurationViews(
+                               instance_, system_id_, kViewConfiguration,
+                               0, &view_count, nullptr),
+                "xrEnumerateViewConfigurationViews(count)");
+        if (view_count != 2) {
+            throw std::runtime_error("probe requires a two-view PRIMARY_STEREO configuration");
+        }
+        view_configuration_views_.assign(
+            view_count, {XR_TYPE_VIEW_CONFIGURATION_VIEW});
+        CheckXr(instance_, xrEnumerateViewConfigurationViews(
+                               instance_, system_id_, kViewConfiguration,
+                               view_count, &view_count, view_configuration_views_.data()),
+                "xrEnumerateViewConfigurationViews");
+
+        uint32_t format_count = 0;
+        CheckXr(instance_, xrEnumerateSwapchainFormats(
+                               session_, 0, &format_count, nullptr),
+                "xrEnumerateSwapchainFormats(count)");
+        std::vector<int64_t> formats(format_count);
+        CheckXr(instance_, xrEnumerateSwapchainFormats(
+                               session_, format_count, &format_count, formats.data()),
+                "xrEnumerateSwapchainFormats");
+        const std::array<int64_t, 4> preferences{
+            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+            DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,
+            DXGI_FORMAT_R8G8B8A8_UNORM,
+            DXGI_FORMAT_B8G8R8A8_UNORM,
+        };
+        const auto preferred = std::find_if(
+            preferences.begin(), preferences.end(), [&](int64_t candidate) {
+                return std::find(formats.begin(), formats.end(), candidate) != formats.end();
+            });
+        if (preferred == preferences.end()) {
+            throw std::runtime_error("runtime exposes no supported RGBA/BGRA render-target format");
+        }
+
+        swapchains_.resize(view_count);
+        for (uint32_t eye = 0; eye < view_count; ++eye) {
+            EyeSwapchain& swapchain = swapchains_[eye];
+            swapchain.width = std::min(
+                view_configuration_views_[eye].recommendedImageRectWidth,
+                kMaximumEyeDimension);
+            swapchain.height = std::min(
+                view_configuration_views_[eye].recommendedImageRectHeight,
+                kMaximumEyeDimension);
+            if (swapchain.width == 0 || swapchain.height == 0) {
+                throw std::runtime_error("runtime returned a zero recommended view dimension");
+            }
+            swapchain.format = *preferred;
+
+            XrSwapchainCreateInfo create_info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+            create_info.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+            create_info.format = swapchain.format;
+            create_info.sampleCount = 1;
+            create_info.width = swapchain.width;
+            create_info.height = swapchain.height;
+            create_info.faceCount = 1;
+            create_info.arraySize = 1;
+            create_info.mipCount = 1;
+            CheckXr(instance_, xrCreateSwapchain(session_, &create_info, &swapchain.handle),
+                    "xrCreateSwapchain");
+
+            uint32_t image_count = 0;
+            CheckXr(instance_, xrEnumerateSwapchainImages(
+                                   swapchain.handle, 0, &image_count, nullptr),
+                    "xrEnumerateSwapchainImages(count)");
+            swapchain.images.assign(image_count, {XR_TYPE_SWAPCHAIN_IMAGE_D3D11_KHR});
+            CheckXr(instance_, xrEnumerateSwapchainImages(
+                                   swapchain.handle, image_count, &image_count,
+                                   reinterpret_cast<XrSwapchainImageBaseHeader*>(
+                                       swapchain.images.data())),
+                    "xrEnumerateSwapchainImages");
+            swapchain.render_targets.resize(image_count);
+            for (uint32_t image = 0; image < image_count; ++image) {
+                ThrowIfFailed(device_->CreateRenderTargetView(
+                                  swapchain.images[image].texture, nullptr,
+                                  &swapchain.render_targets[image]),
+                              "CreateRenderTargetView");
+            }
+
+            D3D11_TEXTURE2D_DESC depth_desc{};
+            depth_desc.Width = swapchain.width;
+            depth_desc.Height = swapchain.height;
+            depth_desc.MipLevels = 1;
+            depth_desc.ArraySize = 1;
+            depth_desc.Format = DXGI_FORMAT_D32_FLOAT;
+            depth_desc.SampleDesc.Count = 1;
+            depth_desc.Usage = D3D11_USAGE_DEFAULT;
+            depth_desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+            ThrowIfFailed(device_->CreateTexture2D(
+                              &depth_desc, nullptr, &swapchain.depth_texture),
+                          "CreateTexture2D(depth)");
+            ThrowIfFailed(device_->CreateDepthStencilView(
+                              swapchain.depth_texture.Get(), nullptr,
+                              &swapchain.depth_target),
+                          "CreateDepthStencilView");
+        }
+
+        renderer_ = std::make_unique<DiagnosticRenderer>();
+        renderer_->Initialize(device_.Get(), context_.Get());
+        std::cout << "Probe swapchains: " << swapchains_[0].width << "x"
+                  << swapchains_[0].height << " per eye\n";
+    }
+
+    bool PollEvents() {
+        for (;;) {
+            XrEventDataBuffer event{XR_TYPE_EVENT_DATA_BUFFER};
+            const XrResult poll_result = xrPollEvent(instance_, &event);
+            if (poll_result == XR_EVENT_UNAVAILABLE) {
+                break;
+            }
+            CheckXr(instance_, poll_result, "xrPollEvent");
+            if (event.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED) {
+                const auto* changed =
+                    reinterpret_cast<const XrEventDataSessionStateChanged*>(&event);
+                session_state_ = changed->state;
+                std::cout << "Session state: " << static_cast<int>(session_state_) << "\n";
+                if (session_state_ == XR_SESSION_STATE_READY && !session_running_) {
+                    const XrSessionBeginInfo begin_info{
+                        XR_TYPE_SESSION_BEGIN_INFO, nullptr, kViewConfiguration};
+                    CheckXr(instance_, xrBeginSession(session_, &begin_info),
+                            "xrBeginSession");
+                    session_running_ = true;
+                } else if (session_state_ == XR_SESSION_STATE_STOPPING && session_running_) {
+                    CheckXr(instance_, xrEndSession(session_), "xrEndSession");
+                    session_running_ = false;
+                } else if (session_state_ == XR_SESSION_STATE_EXITING ||
+                           session_state_ == XR_SESSION_STATE_LOSS_PENDING) {
+                    return false;
+                }
+            } else if (event.type == XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void WaitForSessionReady() {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (!session_running_) {
+            if (!PollEvents()) {
+                throw std::runtime_error("runtime exited before the probe session became ready");
+            }
+            if (std::chrono::steady_clock::now() >= deadline) {
+                throw std::runtime_error(
+                    "timed out waiting for the headset session; wake or wear the headset and retry");
+            }
+            Sleep(10);
+        }
+    }
+
+    WaitedFrame WaitOnCallingThread() {
+        WaitedFrame waited;
+        const XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
+        waited.result = xrWaitFrame(session_, &wait_info, &waited.state);
+        return waited;
+    }
+
+    bool LocateSourceViews(XrTime display_time,
+                           std::array<XrView, 2>* views,
+                           XrViewState* view_state) {
+        *views = {XrView{XR_TYPE_VIEW}, XrView{XR_TYPE_VIEW}};
+        *view_state = {XR_TYPE_VIEW_STATE};
+        const XrViewLocateInfo locate_info{
+            XR_TYPE_VIEW_LOCATE_INFO, nullptr, kViewConfiguration,
+            display_time, source_space_};
+        uint32_t count = 0;
+        CheckXr(instance_, xrLocateViews(session_, &locate_info, view_state,
+                                         static_cast<uint32_t>(views->size()),
+                                         &count, views->data()),
+                "xrLocateViews(source)");
+        constexpr XrViewStateFlags kRequired =
+            XR_VIEW_STATE_ORIENTATION_VALID_BIT | XR_VIEW_STATE_POSITION_VALID_BIT;
+        return count == views->size() &&
+               (view_state->viewStateFlags & kRequired) == kRequired;
+    }
+
+    void LocateTargetViewsForCache(XrTime display_time) {
+        std::array<XrView, 2> target_views{
+            XrView{XR_TYPE_VIEW}, XrView{XR_TYPE_VIEW}};
+        XrViewState target_state{XR_TYPE_VIEW_STATE};
+        const XrViewLocateInfo locate_info{
+            XR_TYPE_VIEW_LOCATE_INFO, nullptr, kViewConfiguration,
+            display_time, target_space_};
+        uint32_t count = 0;
+        CheckXr(instance_, xrLocateViews(session_, &locate_info, &target_state,
+                                         static_cast<uint32_t>(target_views.size()),
+                                         &count, target_views.data()),
+                "xrLocateViews(offset target cache)");
+        if (count != target_views.size()) {
+            throw std::runtime_error("target-space xrLocateViews returned an unexpected view count");
+        }
+    }
+
+    std::optional<XrPosef> LocateSourceInTarget(XrTime display_time) {
+        XrSpaceLocation relation{XR_TYPE_SPACE_LOCATION};
+        const XrResult result = xrLocateSpace(
+            source_space_, target_space_, display_time, &relation);
+        constexpr XrSpaceLocationFlags kRequired =
+            XR_SPACE_LOCATION_ORIENTATION_VALID_BIT |
+            XR_SPACE_LOCATION_POSITION_VALID_BIT;
+        if (XR_FAILED(result) || (relation.locationFlags & kRequired) != kRequired) {
+            ++space_relation_failures_;
+            return std::nullopt;
+        }
+        return relation.pose;
+    }
+
+    void RenderEye(uint32_t eye, const XrView& view) {
+        EyeSwapchain& swapchain = swapchains_[eye];
+        uint32_t image_index = 0;
+        const XrSwapchainImageAcquireInfo acquire_info{
+            XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+        CheckXr(instance_, xrAcquireSwapchainImage(
+                               swapchain.handle, &acquire_info, &image_index),
+                "xrAcquireSwapchainImage");
+        const XrSwapchainImageWaitInfo wait_info{
+            XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO, nullptr, XR_INFINITE_DURATION};
+        CheckXr(instance_, xrWaitSwapchainImage(swapchain.handle, &wait_info),
+                "xrWaitSwapchainImage");
+        renderer_->Render(swapchain.render_targets[image_index].Get(),
+                          swapchain.depth_target.Get(),
+                          swapchain.width, swapchain.height,
+                          view.pose, view.fov, eye);
+        const XrSwapchainImageReleaseInfo release_info{
+            XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+        CheckXr(instance_, xrReleaseSwapchainImage(
+                               swapchain.handle, &release_info),
+                "xrReleaseSwapchainImage");
+    }
+
+    void RenderLoop() {
+        std::unique_ptr<WaitFrameWorker> wait_worker;
+        if (options_.threaded_wait) {
+            wait_worker = std::make_unique<WaitFrameWorker>(session_);
+            wait_worker->Request();
+        }
+        WaitedFrame waited = options_.threaded_wait
+            ? wait_worker->Wait()
+            : WaitOnCallingThread();
+
+        const auto started = std::chrono::steady_clock::now();
+        bool exit_requested = false;
+        while (session_running_ && !exit_requested) {
+            CheckXr(instance_, waited.result, "xrWaitFrame");
+            const XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+            CheckXr(instance_, xrBeginFrame(session_, &begin_info), "xrBeginFrame");
+
+            std::array<XrView, 2> source_views{
+                XrView{XR_TYPE_VIEW}, XrView{XR_TYPE_VIEW}};
+            XrViewState view_state{XR_TYPE_VIEW_STATE};
+            std::array<XrCompositionLayerProjectionView, 2> projection_views{
+                XrCompositionLayerProjectionView{XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW},
+                XrCompositionLayerProjectionView{XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW},
+            };
+            bool submit_projection = false;
+            XrSpace projection_space = source_space_;
+
+            if (waited.state.shouldRender == XR_TRUE &&
+                LocateSourceViews(waited.state.predictedDisplayTime,
+                                  &source_views, &view_state)) {
+                if (options_.mode == ProbeMode::CrossSpaceCached) {
+                    LocateTargetViewsForCache(waited.state.predictedDisplayTime);
+                }
+
+                std::optional<XrPosef> source_in_target;
+                if (options_.mode != ProbeMode::SourceExact) {
+                    source_in_target = LocateSourceInTarget(
+                        waited.state.predictedDisplayTime);
+                    projection_space = target_space_;
+                }
+
+                if (options_.mode == ProbeMode::SourceExact || source_in_target.has_value()) {
+                    for (uint32_t eye = 0; eye < source_views.size(); ++eye) {
+                        RenderEye(eye, source_views[eye]);
+                        projection_views[eye].pose =
+                            source_in_target.has_value()
+                                ? ComposePose(*source_in_target, source_views[eye].pose)
+                                : source_views[eye].pose;
+                        projection_views[eye].fov = source_views[eye].fov;
+                        projection_views[eye].subImage.swapchain =
+                            swapchains_[eye].handle;
+                        projection_views[eye].subImage.imageRect = {
+                            {0, 0},
+                            {static_cast<int32_t>(swapchains_[eye].width),
+                             static_cast<int32_t>(swapchains_[eye].height)},
+                        };
+                        projection_views[eye].subImage.imageArrayIndex = 0;
+                    }
+                    submit_projection = true;
+                }
+            } else if (waited.state.shouldRender == XR_TRUE) {
+                ++invalid_view_frames_;
+            }
+
+            XrCompositionLayerProjection projection{
+                XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+            projection.space = projection_space;
+            projection.viewCount = static_cast<uint32_t>(projection_views.size());
+            projection.views = projection_views.data();
+            const XrCompositionLayerBaseHeader* layers[] = {
+                reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection)};
+
+            const double elapsed = std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - started).count();
+            exit_requested = elapsed >= options_.seconds ||
+                             (GetAsyncKeyState(VK_ESCAPE) & 0x8000) != 0;
+            bool next_wait_requested = false;
+            if (options_.threaded_wait && !exit_requested) {
+                // This is the intentional DCS-style overlap: the persistent
+                // wait thread enters xrWaitFrame(N+1) while this thread is
+                // about to submit xrEndFrame(N).
+                wait_worker->Request();
+                wait_worker->WaitUntilCallStarted();
+                next_wait_requested = true;
+                SwitchToThread();
+            }
+
+            XrFrameEndInfo end_info{XR_TYPE_FRAME_END_INFO};
+            end_info.displayTime = waited.state.predictedDisplayTime;
+            end_info.environmentBlendMode = blend_mode_;
+            end_info.layerCount = submit_projection ? 1u : 0u;
+            end_info.layers = submit_projection ? layers : nullptr;
+            const XrResult end_result = xrEndFrame(session_, &end_info);
+            ++rendered_frames_;
+
+            if (next_wait_requested) {
+                waited = wait_worker->Wait();
+            }
+            CheckXr(instance_, end_result, "xrEndFrame");
+            if (!PollEvents()) {
+                break;
+            }
+            if (exit_requested || !session_running_) {
+                break;
+            }
+            if (!options_.threaded_wait) {
+                waited = WaitOnCallingThread();
+            }
+
+            if (rendered_frames_ % 300 == 0) {
+                std::cout << "Rendered " << rendered_frames_ << " frames\n";
+            }
+        }
+    }
+
+    void RequestAndDrainExit() {
+        if (session_running_) {
+            const XrResult request_result = xrRequestExitSession(session_);
+            if (XR_FAILED(request_result) && request_result != XR_ERROR_SESSION_NOT_RUNNING) {
+                CheckXr(instance_, request_result, "xrRequestExitSession");
+            }
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (session_running_ && std::chrono::steady_clock::now() < deadline) {
+            if (!PollEvents()) {
+                break;
+            }
+            Sleep(10);
+        }
+    }
+
+    Options options_;
+    XrInstance instance_{XR_NULL_HANDLE};
+    XrSystemId system_id_{XR_NULL_SYSTEM_ID};
+    XrSession session_{XR_NULL_HANDLE};
+    XrSpace source_space_{XR_NULL_HANDLE};
+    XrSpace target_space_{XR_NULL_HANDLE};
+    XrSessionState session_state_{XR_SESSION_STATE_UNKNOWN};
+    XrEnvironmentBlendMode blend_mode_{XR_ENVIRONMENT_BLEND_MODE_OPAQUE};
+    bool session_running_{false};
+    ComPtr<ID3D11Device> device_;
+    ComPtr<ID3D11DeviceContext> context_;
+    std::vector<XrViewConfigurationView> view_configuration_views_;
+    std::vector<EyeSwapchain> swapchains_;
+    std::unique_ptr<DiagnosticRenderer> renderer_;
+    uint64_t rendered_frames_{0};
+    uint64_t invalid_view_frames_{0};
+    uint64_t space_relation_failures_{0};
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = ParseOptions(argc, argv);
+        if (options.help) {
+            PrintUsage();
+            return 0;
+        }
+        if (options.self_test) {
+            RunSelfTest();
+            return 0;
+        }
+        ProbeApp(options).Run();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "vectorxr_hardware_probe: " << error.what() << "\n";
+        return 1;
+    }
+}

--- a/release/notes/v0.16.2.md
+++ b/release/notes/v0.16.2.md
@@ -1,0 +1,22 @@
+## Smoother Turbo and More Reliable Pivot
+
+Makes Turbo more dependable in DCS, keeps Pivot movement stable in complex rendering situations, improves Quadviews diagnostics and controller reconnects, and adds a headset test utility for validating future fixes.
+
+### Changes
+
+- <strong>Smoother Turbo</strong>
+  - Fixes a rare freeze that could occur when a game began preparing its next frame unusually early.
+  - Keeps timing consistent when games request extra frame updates and recovers safely when a frame cannot be submitted.
+  - Adds broader automated testing for Turbo startup, steady play, failure recovery, and compatibility fallbacks.
+- <strong>More reliable Pivot movement</strong>
+  - Keeps the same Pivot adjustment throughout each displayed frame, even when a game checks headset tracking more than once.
+  - Corrects Pivot in games that prepare tracking and the final image through different rendering paths, preventing movement from being applied from the wrong point of reference.
+  - Handles unusual rendering layouts more cautiously, preferring an unchanged view over a potentially incorrect Pivot adjustment.
+- <strong>Clearer Quadviews diagnostics and controller recovery</strong>
+  - Keeps Quadviews focus and gaze guides aligned with the image actually being displayed, even when a game prepares frames ahead of time.
+  - Slows repeated checks for unavailable HOTAS and joystick devices instead of retrying every frame, while allowing their bindings to recover automatically when the device returns.
+  - Condenses repeated input failures into concise reconnect updates instead of flooding the log.
+- <strong>A new headset test utility</strong>
+  - Adds an optional visual test app that exercises Pivot and Turbo directly on a real headset without requiring a particular sim, aircraft, or mission.
+  - Includes several Pivot movement scenarios and a Turbo stress test designed to expose timing problems that are difficult to reproduce during normal play.
+  - Creates a repeatable way to confirm changes across different headsets and headset software, helping future fixes arrive with stronger real-hardware validation.


### PR DESCRIPTION
## What changed

- fixes the Turbo async handoff gap that could wedge frame pacing when applications overlap frame preparation and submission
- corrects Pivot logical-frame caching and projection routing across different OpenXR spaces
- keeps Quadviews overlay diagnostics aligned with the frame actually submitted
- adds reconnect backoff for unavailable joystick and HOTAS bindings
- adds automated Turbo pacing coverage and an optional real-headset hardware probe
- prepares the 0.16.2 version metadata, in-app patch notes, and GitHub release notes
- incorporates #73 so the signed release job always gives GitHub CLI an explicit repository context

## Why

DCS flight testing and targeted hardware probes exposed timing and pose-routing cases that are difficult to reproduce organically. The fixes make Turbo and Pivot more dependable while giving future changes a repeatable real-hardware validation path.

PR #73 is included because the publication job intentionally runs without a source checkout; without an explicit repository context, the signed build can succeed but GitHub Release publication can fail afterward.

## User impact

Sim users should see fewer Turbo freezes, more consistent Pivot movement, correctly aligned Quadviews diagnostics, and quieter automatic recovery when a controller is unavailable.

## Validation

- two DCS 0.16.2 test flights, including Pimax FOV crop coverage
- real-runtime probe on Pimax Crystal Super / Pimax OpenXR for source-exact, cross-space, cached-locate, and threaded Async paths
- 35/35 application tests
- 4/4 layer, Turbo, action-set, and hardware-probe tests
- production application build
- `v0.16.2` version consistency check
- clean release diff and verified #73 ancestry
