### PR TITLE
Add Discord community configuration for live testing

### DIFF
--- a/community.json
+++ b/community.json
@@ -1,0 +1,3 @@
+{
+  "discordInvite": "https://discord.gg/UyCt3M4n7N"
+}


### PR DESCRIPTION
Adds the public Discord invite configuration consumed by the 0.17 app's Home and About buttons. Merging this file into master makes the existing raw GitHub endpoint available for live testing without an app build or release.

Only community.json is included. It contains the welcome-and-rules invite: https://discord.gg/UyCt3M4n7N.

Validation: parsed the JSON and verified that the branch diff contains only community.json. After merge, restart the test app or use Retry to verify both Discord buttons against the live endpoint.
